### PR TITLE
Need to set environment to enable Estimators with TF <=1.3 

### DIFF
--- a/pkg/trainer/replicas.go
+++ b/pkg/trainer/replicas.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/tensorflow/k8s/pkg/spec"
 
-	"k8s.io/apimachinery/pkg/conversion"
 	log "github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
+	"k8s.io/apimachinery/pkg/conversion"
 	// TOOO(jlewi): Rename to apiErrors
 	"github.com/tensorflow/k8s/pkg/util"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,11 +45,11 @@ type TFReplicaSetInterface interface {
 type TfConfig struct {
 	// Cluster represents a TensorFlow ClusterSpec.
 	// See: https://www.tensorflow.org/api_docs/python/tf/train/ClusterSpechttps://www.tensorflow.org/api_docs/python/tf/train/ClusterSpec
-	Cluster ClusterSpec            `json:"cluster"`
-	Task    TaskSpec `json:"task"`
+	Cluster ClusterSpec `json:"cluster"`
+	Task    TaskSpec    `json:"task"`
 	// Environment is used by tensorflow.contrib.learn.python.learn in versions <= 1.3
 	// TODO(jlewi): I don't think it is used in versions TF >- 1.4. So we can eventually get rid of it.
-	Environment string             `json:"environment"`
+	Environment string `json:"environment"`
 }
 
 func NewTFReplicaSet(clientSet kubernetes.Interface, tfReplicaSpec spec.TfReplicaSpec, job *TrainingJob) (*TFReplicaSet, error) {
@@ -184,7 +184,7 @@ func (s *TFReplicaSet) Create(config *spec.ControllerConfig) error {
 		// Configure the TFCONFIG environment variable.
 		tfConfig := TfConfig{
 			Cluster: s.Job.ClusterSpec(),
-			Task: TaskSpec {
+			Task: TaskSpec{
 				Type:  strings.ToLower(string(s.Spec.TfReplicaType)),
 				Index: int(index),
 			},

--- a/pkg/trainer/replicas_test.go
+++ b/pkg/trainer/replicas_test.go
@@ -10,12 +10,12 @@ import (
 	"sync"
 	"time"
 
+	"encoding/json"
 	"github.com/tensorflow/k8s/pkg/spec"
 	tfJobFake "github.com/tensorflow/k8s/pkg/util/k8sutil/fake"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api/v1"
-	"encoding/json"
 )
 
 func TestTFReplicaSet(t *testing.T) {
@@ -26,10 +26,10 @@ func TestTFReplicaSet(t *testing.T) {
 			RuntimeId: "some-runtime",
 			ReplicaSpecs: []*spec.TfReplicaSpec{
 				{
-					Replicas:      proto.Int32(2),
-					TfPort:        proto.Int32(10),
-					Template:      &v1.PodTemplateSpec{
-						Spec: v1.PodSpec {
+					Replicas: proto.Int32(2),
+					TfPort:   proto.Int32(10),
+					Template: &v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
 							Containers: []v1.Container{
 								{
 									Name: "tensorflow",
@@ -126,7 +126,7 @@ func TestTFReplicaSet(t *testing.T) {
 			t.Fatalf("Could not unmarshal TfConfig %v", err)
 		}
 
-		expectedTfConfig := &TfConfig {
+		expectedTfConfig := &TfConfig{
 			Cluster: ClusterSpec{},
 			Task: TaskSpec{
 				Type:  "ps",

--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -75,6 +75,11 @@ type TrainingJob struct {
 // It is a map from job names to network addressess.
 type ClusterSpec map[string][]string
 
+type TaskSpec struct {
+	Type string    `json:"type"`
+	Index int      `json:"index"`
+}
+
 func initJob(kubeCli kubernetes.Interface, tfJobClient k8sutil.TfJobClient, job *spec.TfJob, stopC <-chan struct{}, wg *sync.WaitGroup) (*TrainingJob, error) {
 	j := &TrainingJob{
 		KubeCli:     kubeCli,

--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -76,8 +76,8 @@ type TrainingJob struct {
 type ClusterSpec map[string][]string
 
 type TaskSpec struct {
-	Type string    `json:"type"`
-	Index int      `json:"index"`
+	Type  string `json:"type"`
+	Index int    `json:"index"`
 }
 
 func initJob(kubeCli kubernetes.Interface, tfJobClient k8sutil.TfJobClient, job *spec.TfJob, stopC <-chan struct{}, wg *sync.WaitGroup) (*TrainingJob, error) {


### PR DESCRIPTION
* RunConfig (part of Estimator API) depends on the environment being
  set in TF_CONFIG to 'cloud'. If we don't set environment to 'cloud'
  then is_chief isn't enabled for the master and the TF program doesn't
  make progress.

* TF 1.4 should be backwards compatible; i.e. it doesn't make use of
  environment in TF_CONFIG. So this code should be forward compatible.

* Expand the unittest for replicas.go to cover the new code.

* In replicas.go we should make a full DeepCopy of the PodTemplateSpec
  before modifying it. It turns out K8s provides auto-generated code to
  perform deep copies.