### PR TITLE
Update release.py so we can run it continuously.

### DIFF
--- a/py/util.py
+++ b/py/util.py
@@ -8,8 +8,8 @@ import subprocess
 
 # Default name for the repo organization and name.
 # This should match the values used in Go imports.
-MASTER_REPO_OWNER = "jlewi"
-MASTER_REPO_NAME = "mlkube.io"
+MASTER_REPO_OWNER = "tensorflow"
+MASTER_REPO_NAME = "k8s"
 
 
 def run(command, cwd=None):

--- a/release/Dockerfile.release
+++ b/release/Dockerfile.release
@@ -1,0 +1,81 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile is used to create a docker image suitable for building
+# and releasing the TfJob operator.
+FROM golang:1.8.2
+LABEL authors="Jeremy Lewi <jlewi@google.com>"
+
+WORKDIR /workspace
+RUN mkdir -p /workspace
+ENV WORKSPACE=/workspace \
+    TERM=xterm
+
+# common util tools
+# https://github.com/GoogleCloudPlatform/gsutil/issues/446 for python-openssl
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    curl \
+    file \
+    rsync \
+    ca-certificates \
+    build-essential \
+    openssh-client \
+    git \
+    pkg-config \
+    zip \
+    unzip \
+    xz-utils \
+    zlib1g-dev \
+    python \
+    python-setuptools \
+    python-openssl \
+    && apt-get clean
+
+RUN easy_install pip
+RUN pip install --upgrade six pyyaml google-api-python-client \
+    google-cloud-storage pylint
+
+# Install gcloud
+
+ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \
+    tar xzf google-cloud-sdk.tar.gz -C / && \
+    rm google-cloud-sdk.tar.gz && \
+    /google-cloud-sdk/install.sh \
+        --disable-installation-options \
+        --bash-completion=false \
+        --path-update=false \
+        --usage-reporting=false && \
+    gcloud components install alpha beta kubectl && \
+    gcloud info | tee /workspace/gcloud-info.txt
+
+# Install glide
+RUN cd /tmp && \
+    wget -O glide-v0.13.0-linux-amd64.tar.gz \
+            https://github.com/Masterminds/glide/releases/download/v0.13.0/glide-v0.13.0-linux-amd64.tar.gz && \
+    tar -xvf glide-v0.13.0-linux-amd64.tar.gz && \
+    mv ./linux-amd64/glide /usr/local/bin/
+
+# Install docker
+# Docker is used when running locally to build the images.
+# Note: 1.11+ changes the tarball format
+RUN curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz" \
+    | tar -C /usr/bin -xvzf- --strip-components=3 usr/local/bin/docker
+
+RUN mkdir -p /opt
+RUN git clone https://github.com/tensorflow/k8s.git \
+    /opt/git_tensorflow_k8s

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMG = gcr.io/tf-on-k8s-releasing/releaser
+TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+
+all: build
+
+build:
+	@echo {\"image\": \"$(IMG):$(TAG)\"} > version.json
+	docker build -t $(IMG):$(TAG) -f Dockerfile.release .
+	docker tag $(IMG):$(TAG) $(IMG):latest
+	@echo Built $(IMG):$(TAG) and tagged with latest
+	rm -f version.json
+
+push: build
+	gcloud docker -- push $(IMG):$(TAG)
+	gcloud docker -- push $(IMG):latest
+	@echo Pushed $(IMG) with :latest and :$(TAG) tags

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,7 @@
+## Releasing
+
+* The script [release.py](../py/release.py) will build and push a release
+  based on the latest green postsubmit.
+
+* The script can be run continuously and will periodically check for new
+  postsubmit results.

--- a/release/releaser.yaml
+++ b/release/releaser.yaml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1 # for versions before 1.6.0 use extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  name: releaser
+  labels:
+    app: releaser
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: releaser
+  template:
+    metadata:
+      labels:
+        app: releaser
+    spec:
+      containers:
+      - name: releaser
+        image: gcr.io/tf-on-k8s-releasing/releaser:latest
+        workingDir: /opt/git_tensorflow_k8s
+        command:
+          - python
+          - -m
+          - py.release
+          - --check_interval_secs=3600


### PR DESCRIPTION
* release.py will regularly check for postsubmit results and cut new
  releases.

* Create a Docker image to run and it a Kubernetes spec file to deploy it
  on a K8s cluster.

* Fixes #63