### PR TITLE
 Fix bugs in the release script.

### DIFF
--- a/py/release.py
+++ b/py/release.py
@@ -202,6 +202,8 @@ def main():  # pylint: disable=too-many-locals
       logging.info("Sleep %s seconds before checking for a postsubmit.",
                    args.check_interval_secs)
       time.sleep(args.check_interval_secs)
+    else:
+      break
 
 if __name__ == "__main__":
   main()

--- a/py/release.py
+++ b/py/release.py
@@ -81,12 +81,9 @@ def get_last_release(bucket):
     logging.info("File %s doesn't exist.", util.to_gcs_uri(bucket.name, path))
     return ""
 
-
-  data = blob.download_to_string()
-
   contents = blob.download_as_string()
 
-  data = json.dumps(contents)
+  data = json.loads(contents)
   return data.get("sha", "")
 
 def create_latest(bucket, sha, target):
@@ -126,8 +123,8 @@ def build_once(bucket_name):  # pylint: disable=too-many-locals
   src_dir = tempfile.mkdtemp(prefix="tmpTfJobSrc")
   logging.info("src_dir: %s", src_dir)
 
-  sha = util.clone_repo(src_dir, util.MASTER_REPO_OWNER, util.MASTER_REPO_NAME,
-                          sha)
+  _, sha = util.clone_repo(src_dir, util.MASTER_REPO_OWNER, util.MASTER_REPO_NAME,
+                           sha)
 
   # TODO(jlewi): We should check if we've already done a push. We could
   # check if the .tar.gz for the helm package exists.

--- a/py/release.py
+++ b/py/release.py
@@ -23,6 +23,8 @@ REPO_NAME = "k8s"
 RESULTS_BUCKET = "mlkube-testing-results"
 JOB_NAME = "tf-k8s-postsubmit"
 
+GCB_PROJECT = "tf-on-k8s-releasing"
+
 
 def get_latest_green_presubmit(gcs_client):
   bucket = gcs_client.get_bucket(RESULTS_BUCKET)
@@ -133,7 +135,8 @@ def build_once(bucket_name):  # pylint: disable=too-many-locals
   env["GOPATH"] = go_dir
   build_info_file = os.path.join(src_dir, "build_info.yaml")
   util.run([os.path.join(src_dir, "images", "tf_operator", "build_and_push.py"),
-              "--output=" + build_info_file], cwd=src_dir, env=env)
+            "--gcb", "--project=" + GCB_PROJECT,
+            "--output=" + build_info_file], cwd=src_dir, env=env)
 
   with open(build_info_file) as hf:
     build_info = yaml.load(hf)

--- a/py/release.py
+++ b/py/release.py
@@ -162,7 +162,7 @@ def build_once(bucket_name):  # pylint: disable=too-many-locals
 
   targets = [
       os.path.join(release_path, os.path.basename(chart_archive)),
-        "latest/tf-job-operator-chart-latest.tgz",
+      "latest/tf-job-operator-chart-latest.tgz",
     ]
 
   for t in targets:
@@ -174,7 +174,7 @@ def build_once(bucket_name):  # pylint: disable=too-many-locals
     logging.info("Uploading %s to %s.", chart_archive, gcs_path)
     blob.upload_from_filename(chart_archive)
 
-  create_latest(bucket, sha, os.path.join(bucket_name, targets[0]))
+  create_latest(bucket, sha, util.to_gcs_uri(bucket_name, targets[0]))
 
 def main():  # pylint: disable=too-many-locals
   logging.getLogger().setLevel(logging.INFO) # pylint: disable=too-many-locals

--- a/py/util.py
+++ b/py/util.py
@@ -45,11 +45,15 @@ def clone_repo(dest, repo_owner=MASTER_REPO_OWNER, repo_name=MASTER_REPO_NAME,
                sha=None):
   """Clone the repo,
 
-  Returns:
+  Args:
     dest: This is the root path for the training code.
     repo_owner: The owner for github organization.
     repo_name: The repo name.
     sha: The sha number of the repo.
+
+  Returns:
+    dest: Directory where it was checked out
+    sha: The sha of the code.
   """
   # Clone mlkube
   repo = "https://github.com/{0}/{1}.git".format(repo_owner, repo_name)

--- a/py/util.py
+++ b/py/util.py
@@ -12,27 +12,33 @@ MASTER_REPO_OWNER = "tensorflow"
 MASTER_REPO_NAME = "k8s"
 
 
-def run(command, cwd=None):
+def run(command, cwd=None, env=None):
   """Run a subprocess.
 
   Any subprocess output is emitted through the logging modules.
   """
   logging.info("Running: %s \ncwd=%s", " ".join(command), cwd)
 
+  if not env:
+    env = os.environ
+
   try:
-    output = subprocess.check_output(command, cwd=cwd,
+    output = subprocess.check_output(command, cwd=cwd, env=env,
                                      stderr=subprocess.STDOUT)
     logging.info("Subprocess output:\n%s", output)
   except subprocess.CalledProcessError as e:
     logging.info("Subprocess output:\n%s", e.output)
     raise
 
-def run_and_output(command, cwd=None):
+def run_and_output(command, cwd=None, env=None):
   logging.info("Running: %s \ncwd=%s", " ".join(command), cwd)
+
+  if not env:
+    env = os.environ
   # The output won't be available until the command completes.
   # So prefer using run if we don't need to return the output.
   try:
-    output = subprocess.check_output(command, cwd=cwd,
+    output = subprocess.check_output(command, cwd=cwd, env=env,
                                      stderr=subprocess.STDOUT).decode("utf-8")
     logging.info("Subprocess output:\n%s", output)
   except subprocess.CalledProcessError as e:

--- a/release/Dockerfile.release
+++ b/release/Dockerfile.release
@@ -84,5 +84,8 @@ RUN wget -O /tmp/get_helm.sh \
     /tmp/get_helm.sh && \
     rm /tmp/get_helm.sh
 
+# Initialize helm
+RUN helm init --client-only
+
 RUN mkdir -p /opt/tf_k8s_releaser/py
 COPY py /opt/tf_k8s_releaser/py

--- a/release/Dockerfile.release
+++ b/release/Dockerfile.release
@@ -76,5 +76,13 @@ RUN cd /tmp && \
 RUN curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz" \
     | tar -C /usr/bin -xvzf- --strip-components=3 usr/local/bin/docker
 
+# Install Helm
+# Helm is used to build the helm packages.
+RUN wget -O /tmp/get_helm.sh \
+    https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get && \
+    chmod 700 /tmp/get_helm.sh && \
+    /tmp/get_helm.sh && \
+    rm /tmp/get_helm.sh
+
 RUN mkdir -p /opt/tf_k8s_releaser/py
 COPY py /opt/tf_k8s_releaser/py

--- a/release/Dockerfile.release
+++ b/release/Dockerfile.release
@@ -89,3 +89,5 @@ RUN helm init --client-only
 
 RUN mkdir -p /opt/tf_k8s_releaser/py
 COPY py /opt/tf_k8s_releaser/py
+
+ADD ["version.json", "/opt/tf_k8s_releaser/py"]

--- a/release/Dockerfile.release
+++ b/release/Dockerfile.release
@@ -76,6 +76,5 @@ RUN cd /tmp && \
 RUN curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz" \
     | tar -C /usr/bin -xvzf- --strip-components=3 usr/local/bin/docker
 
-RUN mkdir -p /opt
-RUN git clone https://github.com/tensorflow/k8s.git \
-    /opt/git_tensorflow_k8s
+RUN mkdir -p /opt/tf_k8s_releaser/py
+COPY py /opt/tf_k8s_releaser/py

--- a/release/Makefile
+++ b/release/Makefile
@@ -19,10 +19,13 @@ all: build
 
 build:
 	@echo {\"image\": \"$(IMG):$(TAG)\"} > version.json
+	mkdir -p py
+	cp ../py/*.py ./py/
 	docker build -t $(IMG):$(TAG) -f Dockerfile.release .
 	docker tag $(IMG):$(TAG) $(IMG):latest
 	@echo Built $(IMG):$(TAG) and tagged with latest
 	rm -f version.json
+	rm -rf ./py
 
 push: build
 	gcloud docker -- push $(IMG):$(TAG)

--- a/release/README.md
+++ b/release/README.md
@@ -5,3 +5,10 @@
 
 * The script can be run continuously and will periodically check for new
   postsubmit results.
+
+* [Dockerfile.release](Dockerfile.release) and [releaser.yaml](releaser.yaml)
+  provide a Docker image and ReplicaSet spec respectively suitable for running
+  the releaser continuously.
+
+* The releaser should be running continuously on a GKE cluster in project
+  **tf-on-k8s-releasing**.

--- a/release/README.md
+++ b/release/README.md
@@ -12,3 +12,4 @@
 
 * The releaser should be running continuously on a GKE cluster in project
   **tf-on-k8s-releasing**.
+    * Logs are available in [stackdriver](https://console.cloud.google.com/logs/viewer?project=tf-on-k8s-releasing&minLogLevel=0&expandAll=false&timestamp=2017-10-30T16:52:47.000000000Z&dateRangeStart=2017-10-30T15:54:39.682Z&interval=PT2H&resource=container%2Fcluster_name%2Freleasing%2Fnamespace_id%2Fdefault)

--- a/release/releaser.yaml
+++ b/release/releaser.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: releaser
         image: gcr.io/tf-on-k8s-releasing/releaser:latest
-        workingDir: /opt/git_tensorflow_k8s
+        workingDir: /opt/tf_k8s_releaser
         command:
           - python
           - -m

--- a/test-infra/image/Dockerfile
+++ b/test-infra/image/Dockerfile
@@ -84,6 +84,9 @@ RUN wget -O /tmp/get_helm.sh \
     /tmp/get_helm.sh && \
     rm /tmp/get_helm.sh
 
+# Initialize helm
+RUN helm init --client-only
+
 ADD ["bootstrap.py", "/workspace/"]
 ADD ["version.json", "/workspace/"]
 


### PR DESCRIPTION
* Need to set GOPATH properly before building the code.

* Copy the release scripts to the Docker image rather than cloning the
  repo. This makes it easier to push changes to the releaser because
  we can just build the image with local changes. Otherwise we need to
  commit the changes first and then build the Docker image.

* Need to break out of the loop if only building once

* Need to install helm in the releaser image because we use it to build the helm package.

* Need to build the docker images using GCB so we don't need to access docker inside the pod running the releaser.

* Store the image version in a json file inside the container and print out.

* Related to #63 