### PR TITLE
Change group to tensorflow.org and version to v1alpha1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To list jobs
 kubectl get tfjobs
 
 NAME          KINDS
-example-job   TfJob.v1beta1.mlkube.io
+example-job   TfJob.v1alpha.tensorflow.org
 ```
 
 For additional information about motivation and design for the
@@ -146,7 +146,7 @@ kubectl create -f https://raw.githubusercontent.com/tensorflow/k8s/master/exampl
 In this case the job spec looks like the following
 
 ```
-apiVersion: "mlkube.io/v1beta1"
+apiVersion: "tensorflow.org/v1alpha1"
 kind: "TfJob"
 metadata:
   name: "example-job"
@@ -220,7 +220,7 @@ Ensure your K8s cluster is properly configured to use GPUs
 To attach GPUs specify the GPU resource on the container e.g.
 
 ```
-apiVersion: "mlkube.io/v1beta1"
+apiVersion: "tensorflow.org/v1alpha1"
 kind: "TfJob"
 metadata:
   name: "tf-smoke-gpu"
@@ -263,7 +263,7 @@ On Azure you can store your event files on an Azure Files and use
 volumes to make them available to TensorBoard.
 
 ```
-apiVersion: "mlkube.io/v1beta1"
+apiVersion: "tensorflow.org/v1alpha1"
 kind: "TfJob"
 metadata:
   name: "tf-smoke-gpu"
@@ -300,7 +300,7 @@ On GKE you can store your event files on GCS and TensorBoard/TensorFlow
 can read/write directly to GCS.
 
 ```
-apiVersion: "mlkube.io/v1beta1"
+apiVersion: "tensorflow.org/v1alpha1"
 kind: "TfJob"
 metadata:
   name: "tf-smoke-gpu"
@@ -356,7 +356,7 @@ kubectl get -o yaml tfjobs $JOB
 Here is sample output for an example job
 
 ```
-apiVersion: mlkube.io/v1beta1
+apiVersion: tensorflow.org/v1alpha1
 kind: TfJob
 metadata:
   clusterName: ""
@@ -365,7 +365,7 @@ metadata:
   name: example-job
   namespace: default
   resourceVersion: "1881"
-  selfLink: /apis/mlkube.io/v1beta1/namespaces/default/tfjobs/example-job
+  selfLink: /apis/tensorflow.org/v1alpha1/namespaces/default/tfjobs/example-job
   uid: e11f9577-b5e5-11e7-8522-42010a8e01a4
 spec:
   RuntimeId: 76no

--- a/examples/tf_job.yaml
+++ b/examples/tf_job.yaml
@@ -1,4 +1,4 @@
-apiVersion: "mlkube.io/v1beta1"
+apiVersion: "tensorflow.org/v1alpha1"
 kind: "TfJob"
 metadata:
   name: "example-job"

--- a/examples/tf_job/templates/tf_job.yaml
+++ b/examples/tf_job/templates/tf_job.yaml
@@ -1,4 +1,4 @@
-apiVersion: "mlkube.io/v1beta1"
+apiVersion: "tensorflow.org/v1alpha1"
 kind: "TfJob"
 metadata:
   name: {{ .Release.Name }}

--- a/examples/tf_job_defaults.yaml
+++ b/examples/tf_job_defaults.yaml
@@ -1,6 +1,6 @@
 # This template is used to verify that REPLICAS, TfPort, and TfReplicaType are properly set to default
 # values if unspecified by the user.
-apiVersion: "mlkube.io/v1beta1"
+apiVersion: "tensorflow.org/v1alpha1"
 kind: "TfJob"
 metadata:
   name: "example-job-defaults"

--- a/examples/tf_job_gpu.yaml
+++ b/examples/tf_job_gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: "mlkube.io/v1beta1"
+apiVersion: "tensorflow.org/v1alpha1"
 kind: "TfJob"
 metadata:
   name: "tf-smoke-gpu"

--- a/examples/tf_job_tensorboard_azure.yaml
+++ b/examples/tf_job_tensorboard_azure.yaml
@@ -1,4 +1,4 @@
-apiVersion: "mlkube.io/v1beta1"
+apiVersion: "tensorflow.org/v1alpha1"
 kind: "TfJob"
 metadata:
   name: "example-job"

--- a/pkg/spec/tf_job.go
+++ b/pkg/spec/tf_job.go
@@ -15,8 +15,8 @@ import (
 const (
 	CRDKind       = "TfJob"
 	CRDKindPlural = "tfjobs"
-	CRDGroup      = "mlkube.io"
-	CRDVersion    = "v1beta1"
+	CRDGroup      = "tensorflow.org"
+	CRDVersion    = "v1alpha1"
 
 	// Value of the APP label that gets applied to a lot of entities.
 	AppLabel = "tensorflow-job"

--- a/pkg/trainer/replicas.go
+++ b/pkg/trainer/replicas.go
@@ -90,7 +90,7 @@ func NewTFReplicaSet(clientSet kubernetes.Interface, tfReplicaSpec spec.TfReplic
 // Labels returns the labels for this replica set.
 func (s *TFReplicaSet) Labels() KubernetesLabels {
 	return KubernetesLabels(map[string]string{
-		"mlkube.io": "",
+		"tensorflow.org": "",
 		"job_type":  string(s.Spec.TfReplicaType),
 		// runtime_id is set by Job.setup, which is called after the TfReplicaSet is created.
 		// this is why labels aren't a member variable.

--- a/pkg/trainer/replicas_test.go
+++ b/pkg/trainer/replicas_test.go
@@ -65,7 +65,7 @@ func TestTFReplicaSet(t *testing.T) {
 	for index := 0; index < 2; index++ {
 		// Expected labels
 		expectedLabels := map[string]string{
-			"mlkube.io":  "",
+			"tensorflow.org":  "",
 			"task_index": fmt.Sprintf("%v", index),
 			"job_type":   "PS",
 			"runtime_id": "some-runtime",

--- a/pkg/trainer/tensorboard.go
+++ b/pkg/trainer/tensorboard.go
@@ -170,7 +170,7 @@ func (s *TBReplicaSet) getDeploymentSpecTemplate(image string) v1.PodTemplateSpe
 
 func (s *TBReplicaSet) Labels() KubernetesLabels {
 	return KubernetesLabels(map[string]string{
-		"mlkube.io":  "",
+		"tensorflow.org":  "",
 		"runtime_id": s.Job.job.Spec.RuntimeId,
 		"app":        "tensorboard",
 	})

--- a/pkg/trainer/tensorboard_test.go
+++ b/pkg/trainer/tensorboard_test.go
@@ -56,7 +56,7 @@ func TestTBReplicaSet(t *testing.T) {
 
 	// Expected labels
 	expectedLabels := map[string]string{
-		"mlkube.io":  "",
+		"tensorflow.org":  "",
 		"app":        "tensorboard",
 		"runtime_id": "some-runtime",
 	}


### PR DESCRIPTION
* We have abandoned the name mlkube.io and moved the code into tensorflow
  so it makes sense to use tensorflow.org as the group.

* We downgrade the API version from v1beta1 to v1alpha1.
  We want to follow the guidelines used by K8s for alpha, beta, stable:
  https://github.com/kubernetes/community/blob/master/contributors/devel/api_changes.md#alpha-beta-and-stable-versions

  according to this definition we our closer to alpha since the API hasn't
  achieved stability.