### PR TITLE
Fix issue in tpr_util.Delete()

### DIFF
--- a/pkg/util/k8sutil/tpr_util.go
+++ b/pkg/util/k8sutil/tpr_util.go
@@ -128,7 +128,7 @@ func (c *TfJobRestClient) Update(ns string, j *spec.TfJob) (*spec.TfJob, error) 
 }
 
 func (c *TfJobRestClient) Delete(ns, name string) error {
-	_, err := c.restcli.Delete().Resource(spec.CRDKindPlural).Namespace(ns).DoRaw()
+	_, err := c.restcli.Delete().Resource(spec.CRDKindPlural).Namespace(ns).Name(name).DoRaw()
 	return err
 }
 


### PR DESCRIPTION
Currently, calling `Delete()` delete all the jobs in the namespace, even though a `name` is passed as argument.