### PR TITLE
Preliminary example training tf/agents PPO non-distributed

### DIFF
--- a/examples/agents/Dockerfile
+++ b/examples/agents/Dockerfile
@@ -1,0 +1,22 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM {{ base_image }}
+
+RUN apt-get update && apt-get install -y git
+
+ADD . /opt/mlkube
+WORKDIR /opt/mlkube
+
+RUN pip install -r requirements.txt
+
+ENTRYPOINT ["python", "-m", "trainer.task"]

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -1,0 +1,71 @@
+# Tensorflow/agents on k8s
+
+Demonstration of training reinforcement learning agents from [tensorflow/agents](https://github.com/tensorflow/agents) on kubernetes using the tf/k8s CRD.
+
+One approach to run the example is to use the [example runner](https://github.com/tensorflow/k8s/tree/master/py/k8s) to (1) build and deploy the model container and (2) construct, submit, and monitor the job, for example as follows:
+
+```bash
+k8s --mode submit --build_path ${SCRIPT_DIR} \
+    --extra_args '--config pybullet_ant'
+```
+
+Alternatively you may wish to build and deploy images and submit TfJob operations some other way, perhaps building the CRD config manually, in which case the following job config example may be useful:
+
+```yaml
+apiVersion: "tensorflow.org/v1alpha1"
+kind: "TfJob"
+metadata:
+  name: "<your job name>"
+  namespace: default
+spec:
+  replicaSpecs:
+    - replicas: 1
+      tfReplicaType: MASTER
+      template:
+        spec:
+          containers:
+            - image: <repository with worker image>
+              name: tensorflow
+              args: ['--log_dir', 'gs://<bucket path to log dir>', '--config', 'pybullet_ant']
+          restartPolicy: OnFailure
+  tensorBoard:
+    logDir: gs://<bucket path to log dir>
+```
+
+In this example hyperparameters are provided in [trainer/task.py](https://github.com/tensorflow/k8s/tree/master/examples/agents/trainer/task.py):
+
+```python
+def pybullet_ant():
+  # General
+  algorithm = agents.ppo.PPOAlgorithm
+  num_agents = 10
+  eval_episodes = 25
+  use_gpu = False
+  # Environment
+  env = 'AntBulletEnv-v0'
+  max_length = 1000
+  steps = 1e7  # 10M
+  # Network
+  network = agents.scripts.networks.feed_forward_gaussian
+  weight_summaries = dict(
+      all=r'.*',
+      policy=r'.*/policy/.*',
+      value=r'.*/value/.*')
+  policy_layers = 200, 100
+  value_layers = 200, 100
+  init_mean_factor = 0.1
+  init_logstd = -1
+  # Optimization
+  update_every = 30
+  update_epochs = 25
+  #optimizer = 'AdamOptimizer'
+  optimizer = tf.train.AdamOptimizer
+  learning_rate = 1e-4
+  # Losses
+  discount = 0.995
+  kl_target = 1e-2
+  kl_cutoff_factor = 2
+  kl_cutoff_coef = 1000
+  kl_init_penalty = 1
+  return locals()
+```

--- a/examples/agents/requirements.txt
+++ b/examples/agents/requirements.txt
@@ -1,0 +1,3 @@
+-e git://github.com/tensorflow/agents.git#egg=agents
+gym
+pybullet

--- a/examples/agents/run.sh
+++ b/examples/agents/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+example-runner --mode submit --build_path ${SCRIPT_DIR} \
+    --extra_args '--config pybullet_ant'

--- a/examples/agents/setup.py
+++ b/examples/agents/setup.py
@@ -1,0 +1,20 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A setup.py file for the trainer package."""
+from setuptools import find_packages, setup
+
+setup(
+    name='trainer',
+    version='0.0.1',
+    packages=find_packages(),
+    description='A TfJob'
+)

--- a/examples/agents/trainer/task.py
+++ b/examples/agents/trainer/task.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import, division, print_function
+
+import argparse
+import datetime
+import logging
+import os
+
+import agents
+import pybullet_envs  # To make AntBulletEnv-v0 available.
+import tensorflow as tf
+
+
+def pybullet_ant():
+  # General
+  algorithm = agents.ppo.PPOAlgorithm
+  num_agents = 10
+  eval_episodes = 25
+  use_gpu = False
+  # Environment
+  env = 'AntBulletEnv-v0'
+  max_length = 1000
+  steps = 1e7  # 10M
+  # Network
+  network = agents.scripts.networks.feed_forward_gaussian
+  weight_summaries = dict(
+      all=r'.*',
+      policy=r'.*/policy/.*',
+      value=r'.*/value/.*')
+  policy_layers = 200, 100
+  value_layers = 200, 100
+  init_mean_factor = 0.1
+  init_logstd = -1
+  # Optimization
+  update_every = 30
+  update_epochs = 25
+  #optimizer = 'AdamOptimizer'
+  optimizer = tf.train.AdamOptimizer
+  learning_rate = 1e-4
+  # Losses
+  discount = 0.995
+  kl_target = 1e-2
+  kl_cutoff_factor = 2
+  kl_cutoff_coef = 1000
+  kl_init_penalty = 1
+  return locals()
+
+
+def main(args):
+  agents.scripts.utility.set_up_logging()
+  log_dir = args.log_dir and os.path.expanduser(args.log_dir)
+  if log_dir:
+    log_dir = os.path.join(
+        log_dir, '{}-{}'.format(args.timestamp, args.config))
+  if args.mode == 'train':
+    try:
+      # Try to resume training.
+      config = agents.scripts.utility.load_config(args.log_dir)
+    except IOError:
+      # Start new training run.
+      config = agents.tools.AttrDict(globals()[args.config]())
+      config = agents.scripts.utility.save_config(config, log_dir)
+    for score in agents.scripts.train.train(config, env_processes=True):
+      logging.info('Score {}.'.format(score))
+  if args.mode == 'render':
+    agents.scripts.visualize.visualize(
+        logdir=args.log_dir, outdir=args.log_dir, num_agents=1, num_episodes=5,
+        checkpoint=None, env_processes=True)
+
+
+if __name__ == '__main__':
+  timestamp = datetime.datetime.now().strftime('%Y%m%dT%H%M%S')
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--mode', choices=['train', 'render'], default='train')
+  parser.add_argument('--log_dir', default=None, required=True)
+  parser.add_argument('--config', default=None, required=True)
+  parser.add_argument('--timestamp', default=timestamp)
+  args = parser.parse_args()
+  main(args)

--- a/py/example-runner
+++ b/py/example-runner
@@ -1,0 +1,489 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Top-level script for running examples."""
+
+from __future__ import print_function
+
+import argparse
+import datetime
+import logging
+import os
+import pprint
+import StringIO
+import subprocess
+import time
+import urllib
+
+import jinja2
+import kubernetes
+import yaml
+from googleapiclient import discovery
+from jinja2 import Environment
+from kubernetes import client as k8s_client
+from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
+from oauth2client.client import GoogleCredentials
+
+import build_and_push_image
+import util
+
+TF_JOB_KIND = "TfJob"
+TF_JOB_GROUP = "tensorflow.org"
+TF_JOB_VERSION = "v1alpha1"
+TF_JOB_PLURAL = "tfjobs"
+
+# Template for a TfJob CRD YAML
+TFJOB = '''apiVersion: "{{ tf_job_group }}/{{ tf_job_version }}"
+kind: "{{ job_kind }}"
+metadata:
+  name: "{{ job_name }}"
+  namespace: {{ namespace }}
+spec:
+  replicaSpecs:
+    - replicas: 1
+      tfReplicaType: MASTER
+      template:
+        spec:
+          containers:
+            - image: {{ image }}
+              name: tensorflow
+              args: {{ extra_args }}
+          restartPolicy: OnFailure{% if num_workers > 0 %}
+    - replicas: {{ num_workers }}
+      tfReplicaType: WORKER
+      template:
+        spec:
+          containers:
+            - image: {{ image }}
+              name: tensorflow
+          restartPolicy: OnFailure{% endif %}{% if num_ps > 0 %}
+    - replicas: {{ num_ps }}
+      tfReplicaType: PS{% endif %}{% if deploy_tensorboard %}
+  tensorBoard:
+    logDir: {{ job_dir }}
+{% endif %}
+'''
+
+
+def _current_gcloud_project():
+  with open(os.devnull, 'w') as dev_null:
+    return subprocess.check_output(['gcloud', 'config', 'list', 'project',
+                                    '--format=value(core.project)'],
+                                   stderr=dev_null).strip()
+
+
+def _build_and_push_wrapper(model_build_path, skip_push=False):
+  """Wrap build_and_push assuming registry, image label obtained auto. """
+
+  # Get the dockerfile path and verify it is present
+  dockerfile_path = os.path.join(model_build_path, 'Dockerfile')
+  if not os.path.exists(dockerfile_path):
+    dockerfile_path = os.path.join(model_build_path, 'Dockerfile.template')
+    if not os.path.exists(dockerfile_path):
+      raise ValueError('Could not find a Dockerfile or Dockerfile.template at '
+                       'the specified docker build path.')
+
+  image_label = os.path.split(model_build_path)[-1]
+
+  image = 'gcr.io/%s/%s' % (_current_gcloud_project(),
+                            image_label)
+
+  base_images = {
+      "cpu": "gcr.io/tensorflow/tensorflow:1.3.0",
+      "gpu": "gcr.io/tensorflow/tensorflow:1.3.0-gpu",
+  }
+
+  images = build_and_push_image.build_and_push(dockerfile_path, image, modes=None,
+                                               skip_push=skip_push, base_images=base_images)
+
+  return images
+
+
+def _get_api_client():
+  k8s_config.load_kube_config()
+  api_client = k8s_client.ApiClient()
+  return api_client
+
+
+def _generate_job_name(base_tag='tensorflow'):
+  salt = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+  job_name = base_tag + '-' + salt
+  return job_name
+
+
+def _create_job(api_client, args, write_job_config=False):
+
+  crd_api = k8s_client.CustomObjectsApi(api_client)
+
+  extra_args = ['--log_dir', args.job_dir]
+  if args.extra_args is not None:
+    # TODO: Probably want to do some checking
+    extra_args.extend(args.extra_args.split(' '))
+
+  # Could probably just pass kwargs?
+  config = Environment().from_string(TFJOB).render(
+      job_name=args.job_name, tf_job_group=TF_JOB_GROUP,
+      tf_job_version=TF_JOB_VERSION,
+      job_kind=TF_JOB_KIND, namespace=args.namespace,
+      image=args.image, num_workers=args.num_workers,
+      num_ps=args.num_ps, deploy_tensorboard=args.deploy_tensorboard,
+      job_dir=args.job_dir, extra_args=extra_args)
+
+  logging.info('Creating job with config:\n%s' % config)
+
+  body_buffer = StringIO.StringIO(config)
+  body = yaml.load(body_buffer)
+  if args.use_gpu:
+    body['spec']['replicaSpecs'][0]["template"]["spec"]["containers"][0]["resources"] = {
+        "limits": {
+            "nvidia.com/gpu": args.accelerator_count,
+        }
+    }
+
+  if args.mock:
+    logging.info("Running in --mock mode, skipping job submission.")
+    return
+
+  try:
+    # Create a Resource
+    api_response = crd_api.create_namespaced_custom_object(TF_JOB_GROUP,
+                                                           TF_JOB_VERSION, args.namespace, TF_JOB_PLURAL, body)
+    logging.info("Created job %s", api_response["metadata"]["name"])
+  except ApiException as e:
+    print("Exception when calling DefaultApi->apis_fqdn_v1_namespaces_namespace_resource_post: %s\n" %
+          e)
+
+
+def _poll_job(api_client, args):
+
+  if args.mock:
+    logging.info("Running in --mock mode, skipping job polling.")
+    return
+
+  crd_api = k8s_client.CustomObjectsApi(api_client)
+
+  master_started = False
+  runtime_id = None
+
+  core_v1 = k8s_client.CoreV1Api(api_client)
+
+  while True:
+
+    results = crd_api.get_namespaced_custom_object(TF_JOB_GROUP,
+                                                   TF_JOB_VERSION,
+                                                   args.namespace,
+                                                   TF_JOB_PLURAL,
+                                                   args.job_name)
+
+    if not runtime_id:
+      runtime_id = results["spec"]["RuntimeId"]
+      logging.info("Job has runtime id: %s", runtime_id)
+
+      tensorboard_url = "http://127.0.0.1:8001/api/v1/proxy/namespaces/{namespace}/services/tensorboard-{runtime_id}:80/".format(
+          namespace=args.namespace, runtime_id=runtime_id)
+      logging.info("Tensorboard will be available at job\n %s",
+                   tensorboard_url)
+
+    if not master_started:
+      # Get the master pod
+      # TODO(jlewi): V1LabelSelector doesn't seem to help
+      pods = core_v1.list_namespaced_pod(
+          namespace=args.namespace, label_selector="runtime_id={0},job_type=MASTER".format(runtime_id))
+
+    # TODO(jlewi): We should probably handle the case where more than 1 pod gets started.
+    # TODO(jlewi): Once GKE logs pod labels we can just filter by labels to get all logs for a particular task
+    # and not have to identify the actual pod.
+    if pods.items:
+      pod = pods.items[0]
+
+      logging.info("master pod is %s", pod.metadata.name)
+      query = {
+          'advancedFilter': 'resource.type="container"\nresource.labels.namespace_id="default"\nresource.labels.pod_id="{0}"'.format(pod.metadata.name),
+          'dateRangeStart': pod.metadata.creation_timestamp.isoformat(),
+          'expandAll': 'false',
+          'interval': 'NO_LIMIT',
+          'logName': 'projects/{0}/logs/tensorflow'.format(args.project),
+          'project': args.project,
+      }
+      logging.info("Logs will be available in stackdriver at\n"
+                   "https://console.cloud.google.com/logs/viewer?" + urllib.urlencode(query))
+      master_started = True
+
+    if results["status"]["phase"] == "Done":
+      break
+
+    print("Job status {0}".format(results["status"]["phase"]))
+    time.sleep(5)
+
+  logging.info("Job %s", results["status"]["state"])
+
+
+# Top level mode wrappers
+def _run_deployment_mode(args):
+
+  gke_api = discovery.build("container", "v1")
+
+  cluster_request = {
+      "cluster": {
+          "name": args.cluster_name,
+          "description": "A GKE cluster for TF.",
+          "initialNodeCount": 1,
+          "nodeConfig": {
+              "machineType": args.machine_type,
+              "oauthScopes": [
+                  "https://www.googleapis.com/auth/cloud-platform"
+              ],
+          },
+          # TODO(jlewi): Stop pinning GKE version once 1.8 becomes the default.
+          "initialClusterVersion": "1.8.1-gke.1",
+      }
+  }
+
+  if bool(args.accelerator) != (args.accelerator_count > 0):
+    raise ValueError("If accelerator is set accelerator_count must be  > 0")
+
+  if args.use_gpu:  # TODO: Remove this, for development when NVIDIA_K80_GPUS==0
+    if args.accelerator:
+      # TODO(jlewi): Stop enabling Alpha once GPUs make it out of Alpha
+      cluster_request["cluster"]["enableKubernetesAlpha"] = True
+
+      cluster_request["cluster"]["nodeConfig"]["accelerators"] = [
+          {
+              "acceleratorCount": args.accelerator_count,
+              "acceleratorType": args.accelerator,
+          },
+      ]
+
+  logging.info('Creating cluster from config:\n%s' %
+               yaml.dump(cluster_request))
+  util.create_cluster(gke=gke_api, project=args.project, zone=args.zone,
+                      cluster_request=cluster_request)
+  util.configure_kubectl(project=args.project, zone=args.zone,
+                         cluster_name=args.cluster_name)
+
+  api_client = _get_api_client()
+
+  util.setup_cluster(api_client)
+
+
+def _run_submit_mode(args):
+  # Instantiate a Kubernetes API client object
+  api_client = _get_api_client()
+
+  if args.build_path is not None:
+    logging.info('Building image from build path: %s' % args.build_path)
+    if not os.path.exists(args.build_path):
+      raise ValueError('The provided --build_path does not exist, '
+                       'please provide a path to a directory containing '
+                       'a Dockerfile.')
+    images = _build_and_push_wrapper(args.build_path, skip_push=args.mock)
+    if args.use_gpu:
+      args.image = images['gpu']
+    else:
+      args.image = images['cpu']
+  else:
+    if not args.image:
+      logging.error('If new image build is not being performed from '
+                    '--build_path, the image to use for workers and '
+                    'master nodes must be specified with --image.')
+      exit(0)
+
+  logging.info('Initiating training job with parameters:')
+  logging.info('job_name: %s' % args.job_name)
+  logging.info('image: %s' % args.image)
+
+  # Create the training job
+  _create_job(api_client, args, write_job_config=True)
+
+  # # Poll the training job until completion, printing status
+  _poll_job(api_client, args)
+
+
+def _run_monitor_mode(args):
+  # TODO: Ability to easily stream logs from a running job without going to
+  # stackdriver?
+  pass
+
+
+if __name__ == "__main__":
+
+  logging.getLogger().setLevel(logging.INFO)
+  parser = argparse.ArgumentParser(
+      description="Run a tensorflow training job on Kubernetes.")
+
+  parser.add_argument(
+      "--job_base_tag",
+      default="tensorflow",
+      type=str,
+      help="The docker image to use.")
+
+  parser.add_argument(
+      "--job_name",
+      default=None,
+      type=str,
+      help="Optionally, the exact job name to use.")
+
+  parser.add_argument(
+      "--build_path",
+      default=None,
+      type=str,
+      help="Path to a directory containing a model image to be built.")
+
+  parser.add_argument(
+      "--image",
+      default=None,
+      type=str,
+      help="The docker image to use for model instances.")
+
+  parser.add_argument(
+      '--num_workers',
+      default=None,
+      type=str,
+      help='Number of tensorflow workers.')
+
+  parser.add_argument(
+      '--num_param_server',
+      default=None,
+      type=str,
+      help='Number of tensorflow parameter servers.')
+
+  parser.add_argument(
+      '--use_gpu',
+      dest="use_gpu",
+      action="store_true",
+      help='Whether to use GPUs on worker nodes.')
+
+  parser.add_argument(
+      '--project',
+      default=None,
+      type=str,
+      help='GCloud project.')
+
+  parser.add_argument(
+      '--zone',
+      default='us-east1-d',
+      type=str,
+      help='Compute zone.')  # Required for --accelerator=nvidia-tesla-k80?
+
+  parser.add_argument(
+      '--cluster_name',
+      default='gke-tf-example',
+      type=str,
+      help='The name of the kubernetes cluster to create or access.')
+
+  parser.add_argument(
+      '--machine_type',
+      default='n1-standard-8',
+      type=str,
+      help='Base cluster node instance type.')
+
+  parser.add_argument(
+      '--namespace',
+      default='default',
+      type=str,
+      help='The Kubernetes namespace to use (must already exist).')
+  # TODO: Give error when specifying namespace that doesn't already exist or
+  #      create it.
+
+  parser.add_argument(
+      '--registry',
+      default=None,
+      type=str,
+      help='GCloud project.')
+
+  parser.add_argument(
+      '--job_dir',
+      default=None,
+      type=str,
+      help='Workdir on Google Cloud Storage to use for job artifacts.')
+
+  parser.add_argument(
+      '--deploy_tensorboard',
+      default=True,
+      type=bool,
+      help='Whether to deploy tensorboard to monitor training jobs.')
+
+  parser.add_argument(
+      '--accelerator',
+      default='nvidia-tesla-k80',
+      type=str,
+      help='Type of GPU accelerator.')
+
+  parser.add_argument(
+      '--accelerator_count',
+      default="0",
+      type=str,
+      help='Number of accelerators to use.')
+
+  parser.add_argument(
+      '--num_ps',
+      default="1",
+      type=str,
+      help='Number of parameter servers to use.')
+
+  parser.add_argument(
+      '--mode',
+      default=None,
+      type=str,
+      help='Mode in which to run, one of ["deploy", "submit", "monitor"].')
+
+  parser.add_argument(
+      '--mock',
+      default=False,
+      action="store_true",
+      help='Whether to mock the run mode.')
+
+  parser.add_argument(
+      '--extra_args',
+      default=None,
+      type=str,
+      help='Extra arguments to add to the training task command.')
+
+  parser.add_argument(
+      '--deployment_mode',
+      dest="deployment_mode",
+      action="store_true",
+      help='Whether to run in deployment mode.')
+  # TODO: So might at this point be overloading what this one script does...
+
+  args = parser.parse_args()
+
+  if args.project is None:
+    args.project = _current_gcloud_project()
+    logging.info('current project: %s' % args.project)
+
+  if args.registry is not None:
+    args.registry = 'gcr.io/%s' % args.project
+    logging.info('Container registry parameter not provided, assuming '
+                 'gcr.io, i.e. %s' % args.registry)
+
+  if not args.job_name:
+    args.job_name = _generate_job_name(args.job_base_tag)
+
+  if args.job_dir is None:
+    args.job_dir = 'gs://%s-k8s/jobs/%s' % (args.project, args.job_name)
+    # /%s' % (args.project, args.job_name)
+    # args.job_dir = 'gs://%s-k8s/jobs' % args.project
+    # _ensure_bucket(args.job_dir)
+
+  if args.mode is None:
+    raise ValueError('Please specify a run mode with --mode.')
+
+  if args.mode == "deploy":
+    _run_deployment_mode(args)
+  elif args.mode == "submit":
+    _run_submit_mode(args)
+  elif args.mode == "monitor":
+    _run_monitor_mode(args)
+  else:
+    raise ValueError('Unrecognized run --mode, saw: %s' % args.mode)


### PR DESCRIPTION
Squashing old commit, changing author to email recognizable by @googlebot

Date:   Fri Nov 17 09:46:31 2017 -0800

    paring down PR to one example and runner

Date:   Thu Nov 16 10:45:22 2017 -0800

    roll back unintentional changes to getting started notebook

Date:   Thu Nov 16 10:30:29 2017 -0800

    Include client-side stdout for examples/agents

Date:   Thu Nov 16 10:25:37 2017 -0800

    Note quickstart/build.sh not yet functional to avoid confusion.

Date:   Thu Nov 16 10:11:25 2017 -0800

    Preliminary success getting tf/agents PPO to train using a tfjob

    - templating of --log_dir and user --extra_args into k8s job spec
    - updated agents example pybullet_ant config optimizer from string to tf
.train.AdamOptimizer given https://github.com/tensorflow/agents/commit/e7a20
352bdaf3d619ed2fffe239ba25f7fd003ee
    - run scripts for agents and multiply examples
    - example pod logs for agents and multiply examples
    - changed examples/getting_started to examples/quickstart

Date:   Wed Nov 15 15:32:40 2017 -0800

    README was out of date, will update

Date:   Wed Nov 15 15:18:21 2017 -0800

Summary

- In the process of getting tf/agents and baselines agents functioning on tf/k8s.
- Adding some tooling for usability and easing development
- Currently blocked on use of accelerators and debugging new unknown kube error (see below)

Progress

- Runner script as convenient top-level entry to various modes of use
- To increase development leverage and usability of examples
- Job submission and polling (but not log streaming) works fine if cluster configured properly
  - Submission still needs to properly template in --log_dir to confirm the basic multiply example is running correctly; but at least when running in cpu mode it runs to completion without producing any errors.
  - Not going too much toward building an interface still need good way to pass arguments to runs
    - One approach is to emulate cloudml and have all tasks runnable with python -m trainer.task pattern. Alternatively, construct a command that extends this with user arguments and template in command not adding args to an entrypoint...
- Extended runner as interface to calling util.build_and_push_image, beneficial for development, passes name of pushed image through to job config construction

Ongoing/outstanding

- Training jobs that expect accelerators to be available on the cluster fail with an error that does not express this directly, could prevent on front end jobs being submitted to a non-gpu cluster?

- Improve usability of cluster deployment
  - deployment reproducibility / debugging cluster issues that came up when trying to re-deploy with accelerators
  - quota increase is pending
  - e.g. Error: release tf-job failed: namespaces "default" is forbidden: User "system:serviceaccount:kube-system:tiller" cannot get namespaces in the namespace "default": Unknown user "system:serviceaccount:kube-system:tiller"
  - for now switching back to manual deployment from gcloud command line
  - I think the issue might have to do with whether the cluster supports RBAC?

- Debuggability of image pull errors
  - Had issue deploying a TfJob after it working previously
  - Later discovered skip_push was toggled.
  - Might want to check for availability of image specified in job config.
  - Note the value of both pod logs and attempting to launch interactive node for debugging.

- Tentatively re-organized examples directory. Useful?

- Changed various '#!/usr/bin/python' to '#!/usr/bin/env python'

Questions

- Are all GKE clusters enabled with gcr.io pull access by default? (it seems so)