### PR TITLE
Stop hardcoding namespace for TfJob config map

### DIFF
--- a/tf-job-operator-chart/templates/config.yaml
+++ b/tf-job-operator-chart/templates/config.yaml
@@ -5,7 +5,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: tf-job-operator-config
-  namespace: default
 data:
   controller_config_file.yaml: |
     grpcServerFilePath: /opt/mlkube/grpc_tensorflow_server/grpc_tensorflow_server.py
@@ -29,7 +28,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: tf-job-operator-config
-  namespace: default
 data:
   controller_config_file.yaml: |
     grpcServerFilePath: /opt/mlkube/grpc_tensorflow_server/grpc_tensorflow_server.py


### PR DESCRIPTION
Stop hardcoding the namespace for the config map that controls the TfJob operator to default.

* The namespace can be specified using helm install --namespace

* We don't set the namespace for the TfJob controller; so forcing the namespace for the configmap was a bug.