### PR TITLE
replace Google and Golang repos with corresponding github repos

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,7 +1,7 @@
 hash: b9c34817e80d7914b889e41fb456c8b0595f707cf3d2923da3f7b2ac6a6de44a
 updated: 2017-09-29T11:30:21.243398665-04:00
 imports:
-- name: cloud.google.com/go
+- name: github.com/GoogleCloudPlatform/google-cloud-go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
   subpackages:
   - compute/metadata
@@ -78,11 +78,11 @@ imports:
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
-- name: golang.org/x/crypto
+- name: github.com/golang/crypto
   version: d172538b2cfce0c13cee31e647d0367aa8cd2486
   subpackages:
   - ssh/terminal
-- name: golang.org/x/net
+- name: github.com/golang/net
   version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
@@ -91,18 +91,18 @@ imports:
   - http2/hpack
   - idna
   - lex/httplex
-- name: golang.org/x/oauth2
+- name: github.com/golang/oauth2
   version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
   subpackages:
   - google
   - internal
   - jws
   - jwt
-- name: golang.org/x/sys
+- name: github.com/golang/sys
   version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
-- name: golang.org/x/text
+- name: github.com/golang/text
   version: 2910a502d2bf9e43193af9d68ca516529614eed3
   subpackages:
   - cases
@@ -115,9 +115,9 @@ imports:
   - unicode/bidi
   - unicode/norm
   - width
-- name: golang.org/x/time
+- name: github.com/golang/time
   version: 8be79e1e0910c292df4e79c241bb7e8f7e725959
-- name: google.golang.org/appengine
+- name: github.com/golang/appengine
   version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
   subpackages:
   - internal


### PR DESCRIPTION
Fix https://github.com/tensorflow/k8s/issues/171 .

* To better accommodate Chinese contributors we use mirrors of golang.org and google in Github because the former are blocked in China but Github is not. 