### PR TITLE
Fix helm templates so that we don't require a configmap. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ TfJob requires Kubernetes >= 1.8
    CHART=https://storage.googleapis.com/tf-on-k8s-dogfood-releases/latest/tf-job-operator-chart-latest.tgz
    helm install ${CHART} -n tf-job --wait --replace --set rbac.install=true,cloud=<gke or azure>
    ```
-
+   
+   * If you aren't running on GKE or Azure don't set cloud.
+   
    For non-RBAC enabled clusters:
    ```
    CHART=https://storage.googleapis.com/tf-on-k8s-dogfood-releases/latest/tf-job-operator-chart-latest.tgz

--- a/tf-job-operator-chart/templates/deployment.yaml
+++ b/tf-job-operator-chart/templates/deployment.yaml
@@ -17,7 +17,11 @@ spec:
         image: {{ .Values.image }}
         command:
           - /opt/mlkube/tf_operator
+          {{- if .Values.config.configmap }}
+          - --controller_config_file={{ .Values.config.file }}
+          {{- else if .Values.cloud }}
           - --controller_config_file=/etc/config/controller_config_file.yaml
+          {{- end }}
           - -alsologtostderr
           - -v=1
         env:
@@ -29,7 +33,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-
+      {{- if .Values.config.configmap }}       
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/config
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ .Values.config.configmap }}      
+      {{- else if .Values.cloud  }}       
         volumeMounts:
           - name: config-volume
             mountPath: /etc/config
@@ -37,3 +49,4 @@ spec:
         - name: config-volume
           configMap:
             name: tf-job-operator-config
+      {{- end }}

--- a/tf-job-operator-chart/values.yaml
+++ b/tf-job-operator-chart/values.yaml
@@ -4,8 +4,12 @@ test_image: gcr.io/tf-on-k8s-dogfood/tf_sample:dc944ff
 
 # Which cloud provider is kubernetes hosted on.
 # Supported values are gke or azure.
-# If no value is provided, you will have to supply your own configuration, see README.
+# Leave blank to use a default, non-cloud specific config.
 cloud:
+
+config:
+  configmap:
+  file: /etc/config/controller_config_file.yaml
 
 ## Install Default RBAC roles and bindings
 rbac:


### PR DESCRIPTION
* If no --cloud isn't specified then we shouldn't specify
  controller_config_file

* Add options to allow the user to specify the name of a config map
  if they want to set the configmap themselves.

* The options are set so that specifying a custom configmap overrides
  the value selected by setting cloud so that the two options can be used
  together.

Fixes #175 