### PR TITLE
py: Add requirements.txt

### DIFF
--- a/developer_guide.md
+++ b/developer_guide.md
@@ -37,6 +37,7 @@ To build the following artifacts:
 You can run
 
 ```sh
+pip install -r py/requirements.txt
 python -m py.release local --registry=${REGISTRY}
 ```
   * The docker image will be tagged into your registry

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,0 +1,10 @@
+Jinja2>=2.9.5
+requests>=2.14.2
+six>=1.10.0
+protobuf>=3.5.0.post1
+google_api_python_client>=1.6.4
+google-cloud>=0.30.0
+kubernetes>=4.0.0
+mock>=2.0.0
+PyYAML>=3.12
+pyasn1>=0.4.2


### PR DESCRIPTION
The requirements.txt works well for me, I think it is better to add it into the repo.

WDYT

Signed-off-by: Ce Gao <ce.gao@outlook.com>