### PR TITLE
tf_job_design_doc: Fix the apiVersion

### DIFF
--- a/tf_job_design_doc.md
+++ b/tf_job_design_doc.md
@@ -39,7 +39,7 @@ e.g. master, parameter server or worker. The set of replica types can be expande
 
 
 ```
-apiVersion: "mlkube.io/v1beta1"
+apiVersion: "tensorflow.org/v1alpha1"
 kind: "TfJob"
 metadata:
   name: "example-job"


### PR DESCRIPTION
```
error: unable to recognize "./example.yaml": no matches for mlkube.io/, Kind=TfJob
```

PTAL

Signed-off-by: Ce Gao <ce.gao@outlook.com>