### PR TITLE
build_and_push.py: Support python3

### DIFF
--- a/examples/tf_sample/build_and_push.py
+++ b/examples/tf_sample/build_and_push.py
@@ -13,7 +13,7 @@ import jinja2
 def GetGitHash():
   # The image tag is based on the githash.
   git_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
-  git_hash = git_hash.strip()
+  git_hash = git_hash.strip().decode("utf-8")
   modified_files = subprocess.check_output(["git", "ls-files", "--modified"])
   untracked_files = subprocess.check_output(
       ["git", "ls-files", "--others", "--exclude-standard"])


### PR DESCRIPTION
I tried to run the code in python 3 but it fails:

```
Traceback (most recent call last):
  File "./examples/tf_sample/build_and_push.py", line 90, in <module>
    image += ":" + GetGitHash()
TypeError: Can't convert 'bytes' object to str implicitly
```

Adding `decode` makes the code compatible with Python 3.

Signed-off-by: Ce Gao <ce.gao@outlook.com>