### PR TITLE
replace deprecated tf.initialize_all_variables

### DIFF
--- a/examples/tf_sample/tf_sample/tf_smoke.py
+++ b/examples/tf_sample/tf_sample/tf_smoke.py
@@ -59,7 +59,7 @@ def run(server, cluster_spec):  # pylint: disable=too-many-statements, too-many-
           c = tf.multiply(a, b)
           results.append(c)
 
-    init_op = tf.initialize_all_variables()
+    init_op = tf.global_variables_initializer()
 
     if server:
       target = server.target


### PR DESCRIPTION
Replace deprecated `tf.initialize_all_variables` with `tf.global_variables_initializer`. The deprecated API has been removed after 2017-03-02. When users run the example, they would get the WARNING as below:
```
WARNING:tensorflow:From /usr/local/lib/python2.7/dist-packages/tensorflow/python/util/tf_should_use.py:175: initialize_all_variables (from tensorflow.python.ops.variables) is deprecated and will be removed after 2017-03-02.
```
It should be updated with the new and official API `tf.global_variables_initializer`.