### PR TITLE
[WIP] Developer Guide: Add instruction for gcloud python dep.

### DIFF
--- a/developer_guide.md
+++ b/developer_guide.md
@@ -32,9 +32,13 @@ go install github.com/tensorflow/k8s/cmd/tf_operator
 To build the following artifacts:
 
   * Docker image for the operator
-  * Helm chart for deploying it
-
-You can run
+  * Helm chart for deploying it  
+  
+First install the dependency:
+```sh
+pip install --upgrade google-cloud
+```
+Then you can run
 
 ```sh
 python -m py.release local --registry=${REGISTRY}

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -37,6 +37,7 @@ To build the following artifacts:
 First install the dependency:
 ```sh
 pip install --upgrade google-cloud
+pip install --upgrade kubernetes
 ```
 Then you can run
 


### PR DESCRIPTION
Some dependencies such as `kubernetes` and `google-cloud` need to be installed via pip before we can run the release script documented in the developer guide.  

Alternatively we could create a `requirements.txt` file.