### PR TITLE
Fix some cuda issues on Azure

### DIFF
--- a/tf-job-operator-chart/templates/config.yaml
+++ b/tf-job-operator-chart/templates/config.yaml
@@ -10,15 +10,12 @@ data:
     grpcServerFilePath: /opt/mlkube/grpc_tensorflow_server/grpc_tensorflow_server.py
     accelerators:
       alpha.kubernetes.io/nvidia-gpu:
-        envVars:
-          - name: LD_LIBRARY_PATH
-            value: /usr/lib/nvidia:/usr/lib/x86_64-linux-gnu
         volumes:
           - name: lib
-            mountPath: /usr/lib/nvidia
+            mountPath: /usr/local/nvidia/lib64
             hostPath:  /usr/lib/nvidia-384
           - name: bin
-            mountPath: /usr/local/nvidia/bin 
+            mountPath: /usr/local/nvidia/bin
             hostPath: /usr/lib/nvidia-384/bin
           - name: libcuda
             mountPath: /usr/lib/x86_64-linux-gnu/libcuda.so.1


### PR DESCRIPTION
Mount NVIDIA libs in `/usr/local/nvidia/lib64` instead, that way we don't need to update `LD_LIBRARY_PATH`, avoiding some issues with CUDA.