### PR TITLE
Create separate commands to clone and build the repo

### DIFF
--- a/py/release.py
+++ b/py/release.py
@@ -318,10 +318,12 @@ def build(args):
     logging.info("%s does not exist.", go_src_dir)
 
     # Create a symbolic link in the go path.
-    os.makedirs(os.path.dirname(go_src_dir))
+    parent_dir = os.path.dirname(go_src_dir)
+    if not os.path.exists(parent_dir):
+      os.makedirs(parent_dir)
     logging.info("Creating symbolic link %s pointing to %s", go_src_dir,
                  args.src_dir)
-    os.symlink(ars.src_dir, go_src_dir)
+    os.symlink(args.src_dir, go_src_dir)
 
   # Check that the directory in the go src path correctly points to
   # the same directory as args.src_dir
@@ -341,7 +343,7 @@ def build(args):
   vendor_dir = os.path.join(args.src_dir, "vendor")
   if not os.path.exists(vendor_dir):
     logging.info("Installing go dependencies")
-    util.install_go_deps(clone_dir)
+    util.install_go_deps(args.src_dir)
   else:
     logging.info("vendor directory exists; not installing go dependencies.")
 
@@ -630,6 +632,11 @@ def build_parser():
 
 def main():  # pylint: disable=too-many-locals
   logging.getLogger().setLevel(logging.INFO) # pylint: disable=too-many-locals
+  logging.basicConfig(level=logging.INFO,
+                      format=('%(levelname)s|%(asctime)s'
+                              '|%(pathname)s|%(lineno)d| %(message)s'),
+                      datefmt='%Y-%m-%dT%H:%M:%S',
+                      )
 
   parser = build_parser()
 

--- a/py/release_test.py
+++ b/py/release_test.py
@@ -13,7 +13,8 @@ class ReleaseTest(unittest.TestCase):
   @mock.patch("py.release.util.install_go_deps")
   @mock.patch("py.release.util.clone_repo")
   @mock.patch("py.release.build_and_push")
-  def test_build_postsubmit(self, mock_build_and_push, mock_clone, _mock_install, _mock_os, _mock_makedirs):  # pylint: disable=no-self-use
+  def test_build_postsubmit(self, mock_build_and_push, mock_clone,    # pylint: disable=no-self-use
+                            _mock_install, _mock_os, _mock_makedirs):
     parser = release.build_parser()
     args = parser.parse_args(["postsubmit", "--src_dir=/top/src_dir"])
     release.build_postsubmit(args)

--- a/py/util.py
+++ b/py/util.py
@@ -26,7 +26,8 @@ from kubernetes.client import rest
 MASTER_REPO_OWNER = "tensorflow"
 MASTER_REPO_NAME = "k8s"
 
-
+# TODO(jlewi): Should we stream the output by polling the subprocess?
+# look at run_and_stream in build_and_push.
 def run(command, cwd=None, env=None, use_print=False, dryrun=False):
   """Run a subprocess.
 


### PR DESCRIPTION
* The goal is to be able to split cloning the repo and building the artifacts into two steps #189 
* We want cloning the repo to be a separate step because we want to pull release.py from the repo when actually building the code. But in order to invoke release.py from the repo we first have to check it out.

* In a follow on PR we will update the E2E test pipeline to use the new commands.