### PR TITLE
main.go: Add grpc server path check

### DIFF
--- a/cmd/tf_operator/main.go
+++ b/cmd/tf_operator/main.go
@@ -33,6 +33,7 @@ var (
 
 	chaosLevel           int
 	controllerConfigFile string
+	gRPCServerFilePath   string
 	printVersion         bool
 	grpcServerFile       string
 )
@@ -51,6 +52,7 @@ func init() {
 	flag.BoolVar(&printVersion, "version", false, "Show version and quit")
 	flag.DurationVar(&gcInterval, "gc-interval", 10*time.Minute, "GC interval")
 	flag.StringVar(&controllerConfigFile, "controller_config_file", "", "Path to file containing the controller config.")
+	flag.StringVar(&gRPCServerFilePath, "grpc_server_file_path", "", "(MUST Option) Path to grpc_tensorflow_server.py.")
 	flag.Parse()
 
 	// Workaround for watching TPR resource.
@@ -83,6 +85,20 @@ func init() {
 		log.Info("No controller_config_file provided; using empty config.")
 	}
 
+	if err := checkGRPCServerPath(); err != nil {
+		log.Errorf("%v", err)
+		os.Exit(1)
+	}
+}
+
+// checkGRPCServerPath checks if GrpcServerFilePath is defined in controller_config_file or CLI argument, if not return an error
+func checkGRPCServerPath() error {
+	if gRPCServerFilePath == "" {
+		return fmt.Errorf("Could not get grpc_server_file_path")
+	}
+
+	controllerConfig.GrpcServerFilePath = gRPCServerFilePath
+	return nil
 }
 
 func main() {


### PR DESCRIPTION
I keep the config in controller config and add a new CLI argument called `grpc_server_file_path`.

If the GrpcServerFilePath is both configured in controller config and defined via grpc_server_file_path, grpc_server_file_path will override the configuration in controller config. And if neither GrpcServerFilePath nor grpc_server_file_path is defined, operator will exit will error code 1 and output an error log.

### Solve #188

Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/210)
<!-- Reviewable:end -->
