### PR TITLE
On GKE mounting volumes should no longer be required for GPUs.

### DIFF
--- a/tf-job-operator-chart/templates/config.yaml
+++ b/tf-job-operator-chart/templates/config.yaml
@@ -28,13 +28,4 @@ metadata:
 data:
   controller_config_file.yaml: |
     grpcServerFilePath: /opt/mlkube/grpc_tensorflow_server/grpc_tensorflow_server.py
-    accelerators:
-      alpha.kubernetes.io/nvidia-gpu:
-        volumes:
-          - name: nvidia-libraries
-            mountPath: /usr/local/nvidia/lib64 # This path is special; it is expected to be present in `/etc/ld.so.conf` inside the container image.
-            hostPath: /home/kubernetes/bin/nvidia/lib
-          - name: nvidia-debug-tools # optional
-            mountPath: /usr/local/bin/nvidia
-            hostPath: /home/kubernetes/bin/nvidia/bin
 {{ end }}


### PR DESCRIPTION
* GKE uses device plugins so we should no longer need to configure the TfJob
  controller to mount files from the host.

* So we can remove entries from the config map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/217)
<!-- Reviewable:end -->
