### PR TITLE
Don't run glide install in travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,9 @@ go:
   - 1.8
   - 1.9
 
-addons:
-  apt:
-    sources:
-      - sourceline: 'ppa:masterminds/glide'
-    packages:
-      - glide
-
 install:
   # get coveralls.io support
   - go get github.com/mattn/goveralls
-  # Install dependencies using glide
-  - glide install
-  # We need to remove the vendored dependencies of apiextensions otherwise we get type conflicts.
-  - rm -rf vendor/k8s.io/apiextensions-apiserver/vendor
 
 script:
   # We customize the build step because by default


### PR DESCRIPTION
* We now check in the vendor directory so there shouldn't be any reason to run
  glide install in our travis builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/236)
<!-- Reviewable:end -->
