### PR TITLE
Use the release/test python scripts pulled from the repo.

### DIFF
--- a/py/util.py
+++ b/py/util.py
@@ -132,7 +132,7 @@ def clone_repo(dest, repo_owner=MASTER_REPO_OWNER, repo_name=MASTER_REPO_NAME,
 def install_go_deps(src_dir):
   """Run glide to install dependencies."""
   # Install dependencies
-  run(["glide", "install","--strip-vendor"], cwd=src_dir)
+  run(["glide", "install", "--strip-vendor"], cwd=src_dir)
 
 def to_gcs_uri(bucket, path):
   """Convert bucket and path to a GCS URI."""

--- a/py/util.py
+++ b/py/util.py
@@ -37,6 +37,13 @@ def run(command, cwd=None, env=None, use_print=False, dryrun=False):
 
   if not env:
     env = os.environ
+  else:
+    keys = sorted(env.keys())
+
+    lines = []
+    for k in keys:
+      lines.append("{0}={1}".format(k, env[k]))
+    logging.info("Running: Environment:\n%s", "\n".join(lines))
 
   try:
     if dryrun:

--- a/test-infra/airflow/Dockerfile
+++ b/test-infra/airflow/Dockerfile
@@ -152,7 +152,6 @@ RUN mkdir -p /opt/tensorflow_k8s
 COPY py /opt/tensorflow_k8s/py/
 RUN chmod -R a+rw /opt/tensorflow_k8s
 
-ENV PYTHONPATH $PYTHONAPTH:/opt/tensorflow_k8s
 ENV PATH $PATH:/usr/local/go/bin
 
 COPY dags/ /usr/local/airflow/dags

--- a/test-infra/airflow/Dockerfile
+++ b/test-infra/airflow/Dockerfile
@@ -152,6 +152,7 @@ RUN mkdir -p /opt/tensorflow_k8s
 COPY py /opt/tensorflow_k8s/py/
 RUN chmod -R a+rw /opt/tensorflow_k8s
 
+ENV PYTHONPATH $PYTHONAPTH:/opt/tensorflow_k8s
 ENV PATH $PATH:/usr/local/go/bin
 
 COPY dags/ /usr/local/airflow/dags

--- a/test-infra/airflow/Dockerfile.prow
+++ b/test-infra/airflow/Dockerfile.prow
@@ -16,5 +16,5 @@
 #
 # TODO(jlewi) With Docker v17.0 we should just be able to use Docker
 # build args to specify the base image.
-FROM gcr.io/mlkube-testing/airflow:v20171212-08fbbb0-dirty-7c58a7
+FROM gcr.io/mlkube-testing/airflow:v20171220-cb1e053-dirty-08633d
 ENTRYPOINT ["python", "-m", "py.airflow"]

--- a/test-infra/airflow/Dockerfile.prow
+++ b/test-infra/airflow/Dockerfile.prow
@@ -16,5 +16,5 @@
 #
 # TODO(jlewi) With Docker v17.0 we should just be able to use Docker
 # build args to specify the base image.
-FROM gcr.io/mlkube-testing/airflow:v20171221-262a634-e3b0c4
+FROM gcr.io/mlkube-testing/airflow:v20171221-ab407e2-dirty-779423
 ENTRYPOINT ["python", "-m", "py.airflow"]

--- a/test-infra/airflow/Dockerfile.prow
+++ b/test-infra/airflow/Dockerfile.prow
@@ -16,5 +16,5 @@
 #
 # TODO(jlewi) With Docker v17.0 we should just be able to use Docker
 # build args to specify the base image.
-FROM gcr.io/mlkube-testing/airflow:v20171221-0ec90b9-dirty-e21722
+FROM gcr.io/mlkube-testing/airflow:v20171221-19ff62e-e3b0c4
 ENTRYPOINT ["python", "-m", "py.airflow"]

--- a/test-infra/airflow/Dockerfile.prow
+++ b/test-infra/airflow/Dockerfile.prow
@@ -16,5 +16,5 @@
 #
 # TODO(jlewi) With Docker v17.0 we should just be able to use Docker
 # build args to specify the base image.
-FROM gcr.io/mlkube-testing/airflow:v20171221-ab407e2-dirty-779423
+FROM gcr.io/mlkube-testing/airflow:v20171221-09c4868-dirty-46572c
 ENTRYPOINT ["python", "-m", "py.airflow"]

--- a/test-infra/airflow/Dockerfile.prow
+++ b/test-infra/airflow/Dockerfile.prow
@@ -16,5 +16,5 @@
 #
 # TODO(jlewi) With Docker v17.0 we should just be able to use Docker
 # build args to specify the base image.
-FROM gcr.io/mlkube-testing/airflow:v20171220-cb1e053-dirty-08633d
+FROM gcr.io/mlkube-testing/airflow:v20171221-262a634-e3b0c4
 ENTRYPOINT ["python", "-m", "py.airflow"]

--- a/test-infra/airflow/Dockerfile.prow
+++ b/test-infra/airflow/Dockerfile.prow
@@ -16,5 +16,5 @@
 #
 # TODO(jlewi) With Docker v17.0 we should just be able to use Docker
 # build args to specify the base image.
-FROM gcr.io/mlkube-testing/airflow:v20171221-09c4868-dirty-46572c
+FROM gcr.io/mlkube-testing/airflow:v20171221-0ec90b9-dirty-e21722
 ENTRYPOINT ["python", "-m", "py.airflow"]

--- a/test-infra/airflow/dags/e2e_tests_dag.py
+++ b/test-infra/airflow/dags/e2e_tests_dag.py
@@ -79,6 +79,7 @@ def run(ti, *extra_args, **kwargs):
   # unexpected issues by unexpectedly pulling the version baked into the
   # container.
   if bootstrap_dir in python_path:
+    logging.info("Removing %s from PYTHONPATH", bootstrap_dir)
     python_path.remove(bootstrap_dir)
 
   src_dir = ti.xcom_pull(None, key="src_dir")
@@ -118,7 +119,6 @@ def clone_repo(dag_run=None, ti=None, **_kwargs): # pylint: disable=too-many-sta
     conf = {}
   logging.info("conf=%s", conf)
 
-
   # Pick the directory the top level directory to use for this run of the
   # pipeline.
   # This should be a persistent location that is accessible from subsequent
@@ -152,7 +152,7 @@ def clone_repo(dag_run=None, ti=None, **_kwargs): # pylint: disable=too-many-sta
     if commit:
       args.append("--commit=" + commit)
 
-  run(ti, args, use_print=True)
+  run(ti, args, cwd=BOOTSTRAP_DIR, use_print=True)
 
 def build_images(dag_run=None, ti=None, **_kwargs): # pylint: disable=too-many-statements
   """

--- a/test-infra/airflow/deployment.yaml
+++ b/test-infra/airflow/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: airflow
-        image: gcr.io/mlkube-testing/airflow:v20171221-0ec90b9-dirty-e21722
+        image: gcr.io/mlkube-testing/airflow:v20171221-19ff62e-e3b0c4
         # What arguments do we need to set to use the LocalExecutor
         command:
           # Tells entrypoint.sh to start the webserver

--- a/test-infra/airflow/deployment.yaml
+++ b/test-infra/airflow/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: airflow
-        image: gcr.io/mlkube-testing/airflow:v20171220-cb1e053-dirty-08633d
+        image: gcr.io/mlkube-testing/airflow:v20171221-262a634-e3b0c4
         # What arguments do we need to set to use the LocalExecutor
         command:
           # Tells entrypoint.sh to start the webserver

--- a/test-infra/airflow/deployment.yaml
+++ b/test-infra/airflow/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: airflow
-        image: gcr.io/mlkube-testing/airflow:v20171221-262a634-e3b0c4
+        image: gcr.io/mlkube-testing/airflow:v20171221-ab407e2-dirty-779423
         # What arguments do we need to set to use the LocalExecutor
         command:
           # Tells entrypoint.sh to start the webserver

--- a/test-infra/airflow/deployment.yaml
+++ b/test-infra/airflow/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: airflow
-        image: gcr.io/mlkube-testing/airflow:v20171212-08fbbb0-dirty-7c58a7
+        image: gcr.io/mlkube-testing/airflow:v20171220-cb1e053-dirty-08633d
         # What arguments do we need to set to use the LocalExecutor
         command:
           # Tells entrypoint.sh to start the webserver

--- a/test-infra/airflow/deployment.yaml
+++ b/test-infra/airflow/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: airflow
-        image: gcr.io/mlkube-testing/airflow:v20171221-ab407e2-dirty-779423
+        image: gcr.io/mlkube-testing/airflow:v20171221-09c4868-dirty-46572c
         # What arguments do we need to set to use the LocalExecutor
         command:
           # Tells entrypoint.sh to start the webserver

--- a/test-infra/airflow/deployment.yaml
+++ b/test-infra/airflow/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: airflow
-        image: gcr.io/mlkube-testing/airflow:v20171221-09c4868-dirty-46572c
+        image: gcr.io/mlkube-testing/airflow:v20171221-0ec90b9-dirty-e21722
         # What arguments do we need to set to use the LocalExecutor
         command:
           # Tells entrypoint.sh to start the webserver


### PR DESCRIPTION
* The steps in our E2E tests should use the version of the test scripts
  at the revision that is being tested as opposed to the version baked into
  the container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/237)
<!-- Reviewable:end -->
