### PR TITLE
Fix leaking of clusters in E2E tests #80

### DIFF
--- a/test-infra/airflow/Dockerfile.prow
+++ b/test-infra/airflow/Dockerfile.prow
@@ -16,5 +16,5 @@
 #
 # TODO(jlewi) With Docker v17.0 we should just be able to use Docker
 # build args to specify the base image.
-FROM gcr.io/mlkube-testing/airflow:v20171222-f2644ab-dirty-6078d0
+FROM gcr.io/mlkube-testing/airflow:v20171227-e98b10c-dirty-02bfd3
 ENTRYPOINT ["python", "-m", "py.airflow"]

--- a/test-infra/airflow/deployment.yaml
+++ b/test-infra/airflow/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: airflow
-        image: gcr.io/mlkube-testing/airflow:v20171222-f2644ab-dirty-6078d0
+        image: gcr.io/mlkube-testing/airflow:v20171227-e98b10c-dirty-02bfd3
         # What arguments do we need to set to use the LocalExecutor
         command:
           # Tells entrypoint.sh to start the webserver


### PR DESCRIPTION
* setup_cluster needs to push the cluster name so that it is available to
  the teardown step before we try to setup the cluster so that the name
  is available even if setup_cluster fails.

* setup_cluster also needs to handle the case where setup_cluster might
  already have been attempted; in which case we should reuse that cluster.

* Fix #80 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/250)
<!-- Reviewable:end -->
