### PR TITLE
Improve utilities for E2E tests.

### DIFF
--- a/py/airflow.py
+++ b/py/airflow.py
@@ -261,12 +261,17 @@ def main():
   test_dir = tempfile.mkdtemp(prefix="tmpTfCrdTest")
 
   # Setup a logging file handler. This file will be the build log.
-  rootLogger = logging.getLogger()
+  root_logger = logging.getLogger()
 
   build_log = os.path.join(test_dir, "build-log.txt")
-  fileHandler = logging.FileHandler(build_log)
-  # TODO(jlewi): Should we set the formatter?
-  rootLogger.addHandler(fileHandler)
+  file_handler = logging.FileHandler(build_log)
+  # We need to explicitly set the formatter because it will not pick up
+  # the BasicConfig.
+  formatter = logging.Formatter(fmt=("%(levelname)s|%(asctime)s"
+                                     "|%(pathname)s|%(lineno)d| %(message)s"),
+                                datefmt="%Y-%m-%dT%H:%M:%S")
+  file_handler.setFormatter(formatter)
+  root_logger.addHandler(file_handler)
 
   logging.info("test_dir: %s", test_dir)
 
@@ -302,7 +307,7 @@ def main():
 
   prow.create_finished(gcs_client, output_dir, success)
 
-  fileHandler.flush()
+  file_handler.flush()
   prow.upload_outputs(gcs_client, output_dir, build_log)
 
   if not success:

--- a/py/test_util.py
+++ b/py/test_util.py
@@ -7,7 +7,6 @@ import six
 
 from py import util
 
-# TODO(jlewi): How can we indicate that a test wasn't run?
 class TestCase(object):
   def __init__(self, class_name="", name=""):
     self.class_name = class_name
@@ -92,6 +91,9 @@ def wrap_test(test_func, test_case):
 def create_junit_xml_file(test_cases, output_path, gcs_client=None):
   """Create a JUnit XML file.
 
+  The junit schema is specified here:
+  https://www.ibm.com/support/knowledgecenter/en/SSQ2R2_9.5.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html
+
   Args:
     test_cases: TestSuite or List of test case objects.
     output_path: Path to write the XML
@@ -113,8 +115,15 @@ def create_junit_xml_file(test_cases, output_path, gcs_client=None):
     attrib = {
       "classname": c.class_name,
       "name": c.name,
-      "time": "{0}".format(c.time),
     }
+    if c.time:
+      attrib["time"] = "{0}".format(c.time)
+
+    # If the time isn't set and no message is set we interpret that as
+    # the test not being run.
+    if not c.time and not c.failure:
+      attrib["failure"] = "Test was not run."
+
     if c.failure:
       attrib["failure"] = c.failure
     e = ElementTree.Element("testcase", attrib)

--- a/py/test_util.py
+++ b/py/test_util.py
@@ -1,32 +1,107 @@
 import logging
+import subprocess
+import time
 from xml.etree import ElementTree
 
 import six
 
 from py import util
 
+# TODO(jlewi): How can we indicate that a test wasn't run?
 class TestCase(object):
-  def __init__(self):
-    self.class_name = None
-    self.name = None
+  def __init__(self, class_name="", name=""):
+    self.class_name = class_name
+    self.name = name
     # Time in seconds of the test.
     self.time = None
     # String describing the failure.
     self.failure = None
 
+class TestSuite(object):
+  """A suite of test cases."""
+
+  def __init__(self, class_name):
+    self._cases = {}
+    self._class_name = class_name
+
+  def create(self, name):
+    """Create a new TestCase with the specified name.
+
+    Args:
+      name: Name for the newly created TestCase.
+
+    Returns:
+      TestCase: The newly created test case.
+
+    Raises:
+      ValueError: If a test case with the specified name already exists.
+    """
+    if name in self._cases:
+      raise ValueError("TestSuite already has a test named %s" % name)
+    self._cases[name] = TestCase()
+    self._cases[name].class_name = self._class_name
+    self._cases[name].name = name
+    return self._cases[name]
+
+  def get(self, name):
+    """Get the specified test case.
+
+    Args:
+      name: Name of the test case to return.
+
+    Returns:
+      TestCase: The requested test case.
+
+    Raises:
+      KeyError: If no test with that name exists.
+    """
+    if not name in self._cases:
+      raise KeyError("No TestCase named %s" % name)
+    return self._cases[name]
+
+  def __iter__(self):
+    """Return an iterator of TestCases."""
+    return six.itervalues(self._cases)
+
+def wrap_test(test_func, test_case):
+  """Wrap a test func.
+
+  Test_func is a callable that contains the commands to perform a particular
+  test.
+
+  Args:
+    test_func: The callable to invoke.
+    test_case: A TestCase to be populated.
+
+  Raises:
+    Exceptions are reraised to indicate test failure.
+  """
+  start = time.time()
+  try:
+    test_func()
+  except subprocess.CalledProcessError as e:
+    test_case.failure = (
+       "Subprocess failed;\n{0}".format(e.output))
+    raise
+  except Exception as e:
+    test_case.failure = "Test failed; " + e.message
+    raise
+  finally:
+    test_case.time = time.time() - start
 
 def create_junit_xml_file(test_cases, output_path, gcs_client=None):
   """Create a JUnit XML file.
 
   Args:
-    test_cases: List of test case objects.
+    test_cases: TestSuite or List of test case objects.
     output_path: Path to write the XML
     gcs_client: GCS client to use if output is GCS.
   """
   total_time = 0
   failures = 0
   for c in test_cases:
-    total_time += c.time
+    if c.time:
+      total_time += c.time
 
     if c.failure:
       failures += 1
@@ -47,7 +122,7 @@ def create_junit_xml_file(test_cases, output_path, gcs_client=None):
     root.append(e)
 
   t = ElementTree.ElementTree(root)
-  logging.info("Creationg %s", output_path)
+  logging.info("Creating %s", output_path)
   if output_path.startswith("gs://"):
     b = six.StringIO()
     t.write(b)

--- a/py/util.py
+++ b/py/util.py
@@ -5,7 +5,6 @@ import datetime
 import logging
 import os
 import re
-import shutil
 import subprocess
 import time
 import urllib
@@ -254,7 +253,10 @@ def wait_for_deployment(api_client, namespace, name):
   Args:
     api_client: K8s api client to use.
     namespace: The name space for the deployment.
-    name: The name of the deployment):
+    name: The name of the deployment.
+
+  Returns:
+    deploy: The deploy object describing the deployment.
 
   Raises:
     TimeoutError: If timeout waiting for deployment to be ready.
@@ -268,14 +270,47 @@ def wait_for_deployment(api_client, namespace, name):
     deploy = ext_client.read_namespaced_deployment(name, namespace)
     if deploy.status.ready_replicas >= 1:
       logging.info("Deployment %s in namespace %s is ready", name, namespace)
-      return
-    logging.info("Waiting for deployment %s in namespace %s",  name, namespace)
+      return deploy
+    logging.info("Waiting for deployment %s in namespace %s", name, namespace)
     time.sleep(10)
 
   logging.error("Timeout waiting for deployment %s in namespace %s to be "
                 "ready", name, namespace)
   raise TimeoutError(
       "Timeout waiting for deployment {0} in namespace {1}".format(
+      name, namespace))
+
+def wait_for_statefulset(api_client, namespace, name):
+  """Wait for deployment to be ready.
+
+  Args:
+    api_client: K8s api client to use.
+    namespace: The name space for the deployment.
+    name: The name of the stateful set.
+
+  Returns:
+    deploy: The deploy object describing the deployment.
+
+  Raises:
+    TimeoutError: If timeout waiting for deployment to be ready.
+  """
+  # Wait for tiller to be ready
+  end_time = datetime.datetime.now() + datetime.timedelta(minutes=2)
+
+  apps_client = k8s_client.AppsV1beta1Api(api_client)
+
+  while datetime.datetime.now() < end_time:
+    stateful = apps_client.read_namespaced_stateful_set(name, namespace)
+    if stateful.status.ready_replicas >= 1:
+      logging.info("Statefulset %s in namespace %s is ready", name, namespace)
+      return stateful
+    logging.info("Waiting for Statefulset %s in namespace %s", name, namespace)
+    time.sleep(10)
+
+  logging.error("Timeout waiting for statefulset %s in namespace %s to be "
+                "ready", name, namespace)
+  raise TimeoutError(
+      "Timeout waiting for statefulset {0} in namespace {1}".format(
       name, namespace))
 
 def install_gpu_drivers(api_client):

--- a/py/util_test.py
+++ b/py/util_test.py
@@ -1,140 +1,11 @@
 from __future__ import print_function
 
-from kubernetes import client as k8s_client
-import mock
 import unittest
 
-from py import util
+from kubernetes import client as k8s_client
+import mock
 
-DEPLOYMENT_READY = """{
-    "apiVersion": "v1",
-    "items": [
-        {
-            "apiVersion": "extensions/v1beta1",
-            "kind": "Deployment",
-            "metadata": {
-                "annotations": {
-                    "deployment.kubernetes.io/revision": "1"
-                },
-                "creationTimestamp": "2017-12-22T13:58:29Z",
-                "generation": 1,
-                "labels": {
-                    "name": "tf-job-operator"
-                },
-                "name": "tf-job-operator",
-                "namespace": "default",
-                "resourceVersion": "666",
-                "selfLink": "/apis/extensions/v1beta1/namespaces/default/deployments/tf-job-operator",
-                "uid": "3060361a-e720-11e7-ada7-42010a8e00a9"
-            },
-            "spec": {
-                "replicas": 1,
-                "selector": {
-                    "matchLabels": {
-                        "name": "tf-job-operator"
-                    }
-                },
-                "strategy": {
-                    "rollingUpdate": {
-                        "maxSurge": 1,
-                        "maxUnavailable": 1
-                    },
-                    "type": "RollingUpdate"
-                },
-                "template": {
-                    "metadata": {
-                        "creationTimestamp": null,
-                        "labels": {
-                            "name": "tf-job-operator"
-                        }
-                    },
-                    "spec": {
-                        "containers": [
-                            {
-                                "command": [
-                                    "/opt/mlkube/tf_operator",
-                                    "--controller_config_file=/etc/config/controller_config_file.yaml",
-                                    "-alsologtostderr",
-                                    "-v=1"
-                                ],
-                                "env": [
-                                    {
-                                        "name": "MY_POD_NAMESPACE",
-                                        "valueFrom": {
-                                            "fieldRef": {
-                                                "apiVersion": "v1",
-                                                "fieldPath": "metadata.namespace"
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "name": "MY_POD_NAME",
-                                        "valueFrom": {
-                                            "fieldRef": {
-                                                "apiVersion": "v1",
-                                                "fieldPath": "metadata.name"
-                                            }
-                                        }
-                                    }
-                                ],
-                                "image": "gcr.io/mlkube-testing/tf_operator:v20171222-e108d55",
-                                "imagePullPolicy": "IfNotPresent",
-                                "name": "tf-job-operator",
-                                "resources": {},
-                                "terminationMessagePath": "/dev/termination-log",
-                                "terminationMessagePolicy": "File",
-                                "volumeMounts": [
-                                    {
-                                        "mountPath": "/etc/config",
-                                        "name": "config-volume"
-                                    }
-                                ]
-                            }
-                        ],
-                        "dnsPolicy": "ClusterFirst",
-                        "restartPolicy": "Always",
-                        "schedulerName": "default-scheduler",
-                        "securityContext": {},
-                        "serviceAccount": "tf-job-operator",
-                        "serviceAccountName": "tf-job-operator",
-                        "terminationGracePeriodSeconds": 30,
-                        "volumes": [
-                            {
-                                "configMap": {
-                                    "defaultMode": 420,
-                                    "name": "tf-job-operator-config"
-                                },
-                                "name": "config-volume"
-                            }
-                        ]
-                    }
-                }
-            },
-            "status": {
-                "availableReplicas": 1,
-                "conditions": [
-                    {
-                        "lastTransitionTime": "2017-12-22T13:58:29Z",
-                        "lastUpdateTime": "2017-12-22T13:58:29Z",
-                        "message": "Deployment has minimum availability.",
-                        "reason": "MinimumReplicasAvailable",
-                        "status": "True",
-                        "type": "Available"
-                    }
-                ],
-                "observedGeneration": 1,
-                "readyReplicas": 1,
-                "replicas": 1,
-                "updatedReplicas": 1
-            }
-        }
-    ],
-    "kind": "List",
-    "metadata": {
-        "resourceVersion": "",
-        "selfLink": ""
-    }
-}"""
+from py import util
 
 class UtilTest(unittest.TestCase):
   def test_wait_for_deployment(self):
@@ -144,8 +15,17 @@ class UtilTest(unittest.TestCase):
     response.status = k8s_client.ExtensionsV1beta1DeploymentStatus()
     response.status.ready_replicas = 1
     api_client.call_api.return_value = response
-    util.wait_for_deployment(api_client, "some-namespace", "some-deployment")
+    result = util.wait_for_deployment(api_client, "some-namespace", "some-deployment")
+    self.assertIsNotNone(result)
 
+  def test_wait_for_statefulset(self):
+    api_client = mock.MagicMock(spec=k8s_client.ApiClient)
+
+    response = k8s_client.V1beta1StatefulSet()
+    response.status = k8s_client.V1beta1StatefulSetStatus(ready_replicas=1, replicas=1)
+    api_client.call_api.return_value = response
+    result = util.wait_for_statefulset(api_client, "some-namespace", "some-set")
+    self.assertIsNotNone(result)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
* Define a wrap_test function that takes care of some of the repitive work
  of configuring a TestCase object.

* Define a TestSuite class to represent more than 1 TestCase.
  * This should make it easy to define a suite of TestCases ahead of time
    so that if we abort early, the junit file will still have an entry for
    all test cases even the ones that didn't get run.

* airflow.py should set the logging formatter for the logger that logs to a
  file. The file handler doesn't appear to pick up the BasicConfig.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/251)
<!-- Reviewable:end -->
