### PR TITLE
apply goimports -w to generated files

### DIFF
--- a/linter_config.json
+++ b/linter_config.json
@@ -19,7 +19,11 @@
   "Aggregate": true,
   "WarnUnmatchedNolint": true,
   "LineLength": 240,
-  "Exclude": ["comment or be unexported", "comment on exported"],
+  "Exclude": [
+    "redundant return statement",
+    "comment or be unexported",
+    "comment on exported"
+  ],
   "Deadline": "300s",
   "Skip": ["bin", "py"]
 }

--- a/pkg/apis/tensorflow/helper/helpers.go
+++ b/pkg/apis/tensorflow/helper/helpers.go
@@ -1,11 +1,12 @@
 package helper
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	tfv1 "github.com/tensorflow/k8s/pkg/apis/tensorflow/v1alpha1"
 	"fmt"
-	"k8s.io/api/core/v1"
+
+	tfv1 "github.com/tensorflow/k8s/pkg/apis/tensorflow/v1alpha1"
 	"github.com/tensorflow/k8s/pkg/util"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // AsOwner make OwnerReference according to the parameter

--- a/pkg/apis/tensorflow/helper/helpers_test.go
+++ b/pkg/apis/tensorflow/helper/helpers_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/tensorflow/k8s/pkg/util"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/api/core/v1"
 	tfv1 "github.com/tensorflow/k8s/pkg/apis/tensorflow/v1alpha1"
+	"github.com/tensorflow/k8s/pkg/util"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestAddAccelertor(t *testing.T) {

--- a/pkg/apis/tensorflow/v1alpha1/defaults.go
+++ b/pkg/apis/tensorflow/v1alpha1/defaults.go
@@ -6,11 +6,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
-
 
 // SetDefaults_TfJob sets any unspecified values to defaults
 func SetDefaults_TfJob(obj *TfJob) {
@@ -71,4 +69,3 @@ func setDefault_PSPodTemplateSpec(r *TfReplicaSpec, tfImage string) {
 		},
 	}
 }
-

--- a/pkg/apis/tensorflow/v1alpha1/register.go
+++ b/pkg/apis/tensorflow/v1alpha1/register.go
@@ -1,14 +1,14 @@
 package v1alpha1
 
 import (
-  metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-  "k8s.io/apimachinery/pkg/runtime"
-  "k8s.io/apimachinery/pkg/runtime/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var (
-  SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-  AddToScheme   = SchemeBuilder.AddToScheme
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
 // GroupName is the group name use in this package
@@ -19,16 +19,16 @@ var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: CRDVersi
 
 // Resource takes an unqualified resource and returns a Group-qualified GroupResource.
 func Resource(resource string) schema.GroupResource {
-  return SchemeGroupVersion.WithResource(resource).GroupResource()
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
 // addKnownTypes adds the set of types defined in this package to the supplied scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-  scheme.AddKnownTypes(SchemeGroupVersion,
-    &TfJob{},
-    &TfJobList{},
-  )
-  metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&TfJob{},
+		&TfJobList{},
+	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 
-  return nil
+	return nil
 }

--- a/pkg/apis/tensorflow/v1alpha1/types.go
+++ b/pkg/apis/tensorflow/v1alpha1/types.go
@@ -1,8 +1,8 @@
 package v1alpha1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -24,10 +24,10 @@ const (
 
 // TFJob describes tfjob info
 type TfJob struct {
-	metav1.TypeMeta    `json:",inline"`
-	metav1.ObjectMeta  `json:"metadata,omitempty"`
-	Spec   TfJobSpec   `json:"spec"`
-	Status TfJobStatus `json:"status"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              TfJobSpec   `json:"spec"`
+	Status            TfJobStatus `json:"status"`
 }
 
 type TfJobSpec struct {
@@ -58,7 +58,6 @@ type ChiefSpec struct {
 	ReplicaIndex int    `json:"replicaIndex"`
 }
 
-
 // TfReplicaType determines how a set of TF processes are handled.
 type TfReplicaType string
 
@@ -87,7 +86,7 @@ type TfReplicaSpec struct {
 	Replicas *int32              `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 	Template *v1.PodTemplateSpec `json:"template,omitempty" protobuf:"bytes,3,opt,name=template"`
 	// TfPort is the port to use for TF services.
-	TfPort *int32 `json:"tfPort,omitempty" protobuf:"varint,1,opt,name=tfPort"`
+	TfPort        *int32 `json:"tfPort,omitempty" protobuf:"varint,1,opt,name=tfPort"`
 	TfReplicaType `json:"tfReplicaType"`
 	// IsDefaultPS denotes if the parameter server should use the default grpc_tensorflow_server
 	IsDefaultPS bool

--- a/pkg/apis/tensorflow/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/tensorflow/v1alpha1/zz_generated.deepcopy.go
@@ -21,10 +21,11 @@ limitations under the License.
 package v1alpha1
 
 import (
+	reflect "reflect"
+
 	v1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
-	reflect "reflect"
 )
 
 func init() {

--- a/pkg/apis/tensorflow/validation/validation.go
+++ b/pkg/apis/tensorflow/validation/validation.go
@@ -1,10 +1,11 @@
 package validation
 
 import (
+	"errors"
+	"fmt"
+
 	tfv1 "github.com/tensorflow/k8s/pkg/apis/tensorflow/v1alpha1"
 	"github.com/tensorflow/k8s/pkg/util"
-	"fmt"
-	"errors"
 )
 
 // ValidateTfJobSpec checks that the TfJobSpec is valid.

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -26,7 +26,9 @@ import (
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
-var parameterCodec = runtime.NewParameterCodec(scheme)
+
+// TODO: unused
+// var parameterCodec = runtime.NewParameterCodec(scheme)
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
@@ -48,6 +50,7 @@ func init() {
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
-	tensorflowv1alpha1.AddToScheme(scheme)
-
+	if err := tensorflowv1alpha1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
 }

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -48,6 +48,7 @@ func init() {
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.
 func AddToScheme(scheme *runtime.Scheme) {
-	tensorflowv1alpha1.AddToScheme(scheme)
-
+	if err := tensorflowv1alpha1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
 }

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -19,15 +19,16 @@ limitations under the License.
 package externalversions
 
 import (
+	reflect "reflect"
+	sync "sync"
+	time "time"
+
 	versioned "github.com/tensorflow/k8s/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/tensorflow/k8s/pkg/client/informers/externalversions/internalinterfaces"
 	tensorflow "github.com/tensorflow/k8s/pkg/client/informers/externalversions/tensorflow"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
-	reflect "reflect"
-	sync "sync"
-	time "time"
 )
 
 type sharedInformerFactory struct {

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -20,6 +20,7 @@ package externalversions
 
 import (
 	"fmt"
+
 	v1alpha1 "github.com/tensorflow/k8s/pkg/apis/tensorflow/v1alpha1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -19,10 +19,11 @@ limitations under the License.
 package internalinterfaces
 
 import (
+	time "time"
+
 	versioned "github.com/tensorflow/k8s/pkg/client/clientset/versioned"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
-	time "time"
 )
 
 type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexInformer

--- a/pkg/client/informers/externalversions/tensorflow/v1alpha1/tfjob.go
+++ b/pkg/client/informers/externalversions/tensorflow/v1alpha1/tfjob.go
@@ -19,6 +19,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	time "time"
+
 	tensorflow_v1alpha1 "github.com/tensorflow/k8s/pkg/apis/tensorflow/v1alpha1"
 	versioned "github.com/tensorflow/k8s/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/tensorflow/k8s/pkg/client/informers/externalversions/internalinterfaces"
@@ -27,7 +29,6 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
 	cache "k8s.io/client-go/tools/cache"
-	time "time"
 )
 
 // TfJobInformer provides access to a shared informer and lister for


### PR DESCRIPTION
fixes #256

No good way to tell whether a file was generated. a better way is to ensure that all files and newly submitted ones are `goimport`ed. also from now on I think it is better to enforce that even generated code are pre-`goimport`ed.

I didn't fix all the lint warnings because I am afraid of changing any code other than using `goimport`. I suggest that the original author do the changes instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/257)
<!-- Reviewable:end -->
