### PR TITLE
refactor dashboard backend, use versioned tfjob clientset

### DIFF
--- a/dashboard/backend/client/manager.go
+++ b/dashboard/backend/client/manager.go
@@ -2,6 +2,7 @@
 package client
 
 import (
+	"github.com/tensorflow/k8s/pkg/client/clientset/versioned"
 	"github.com/tensorflow/k8s/pkg/util/k8sutil"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -12,7 +13,7 @@ import (
 type ClientManager struct {
 	restCfg     *rest.Config
 	ClientSet   *kubernetes.Clientset
-	TfJobClient *k8sutil.TfJobRestClient
+	TfJobClient *versioned.Clientset
 }
 
 func (c *ClientManager) init() {
@@ -28,10 +29,8 @@ func (c *ClientManager) init() {
 	}
 	c.ClientSet = clientset
 
-	tfJobClient, err := k8sutil.NewTfJobClient()
-	if err != nil {
-		panic(err)
-	}
+	tfJobClient := versioned.NewForConfigOrDie(c.restCfg)
+
 	c.TfJobClient = tfJobClient
 }
 

--- a/dashboard/backend/handler/api_handler.go
+++ b/dashboard/backend/handler/api_handler.go
@@ -8,7 +8,7 @@ import (
 
 	restful "github.com/emicklei/go-restful"
 	"github.com/tensorflow/k8s/dashboard/backend/client"
-	"github.com/tensorflow/k8s/pkg/spec"
+	"github.com/tensorflow/k8s/pkg/apis/tensorflow/v1alpha1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -21,14 +21,14 @@ type APIHandler struct {
 // TfJobDetail describe the specification of a TfJob
 // as well as related TensorBoard service if any and related pods
 type TfJobDetail struct {
-	TfJob     *spec.TfJob `json:"tfJob"`
-	TbService *v1.Service `json:"tbService"`
-	Pods      []v1.Pod    `json:"pods"`
+	TfJob     *v1alpha1.TfJob `json:"tfJob"`
+	TbService *v1.Service     `json:"tbService"`
+	Pods      []v1.Pod        `json:"pods"`
 }
 
 // TfJobList is a list of TfJobs
 type TfJobList struct {
-	tfJobs []spec.TfJob `json:"TfJobs"`
+	tfJobs []v1alpha1.TfJob `json:"TfJobs"`
 }
 
 // CreateHTTPAPIHandler creates the restful Container and defines the routes the API will serve
@@ -69,8 +69,8 @@ func CreateHTTPAPIHandler(client client.ClientManager) (http.Handler, error) {
 	apiV1Ws.Route(
 		apiV1Ws.POST("/tfjob").
 			To(apiHandler.handleDeploy).
-			Reads(spec.TfJob{}).
-			Writes(spec.TfJob{}))
+			Reads(v1alpha1.TfJob{}).
+			Writes(v1alpha1.TfJob{}))
 
 	apiV1Ws.Route(
 		apiV1Ws.DELETE("/tfjob/{namespace}/{tfjob}").
@@ -88,7 +88,7 @@ func CreateHTTPAPIHandler(client client.ClientManager) (http.Handler, error) {
 func (apiHandler *APIHandler) handleGetTfJobs(request *restful.Request, response *restful.Response) {
 
 	//TODO: namespace handling
-	jobs, err := apiHandler.cManager.TfJobClient.List("default")
+	jobs, err := apiHandler.cManager.TfJobClient.TensorflowV1alpha1().TfJobs("default").List(metav1.ListOptions{})
 
 	if err != nil {
 		panic(err)
@@ -101,7 +101,7 @@ func (apiHandler *APIHandler) handleGetTfJobDetail(request *restful.Request, res
 	namespace := request.PathParameter("namespace")
 	name := request.PathParameter("tfjob")
 
-	job, err := apiHandler.cManager.TfJobClient.Get(namespace, name)
+	job, err := apiHandler.cManager.TfJobClient.TensorflowV1alpha1().TfJobs(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		panic(err)
 	}
@@ -123,7 +123,7 @@ func (apiHandler *APIHandler) handleGetTfJobDetail(request *restful.Request, res
 			// Handle case where no tensorboard is found
 			tfJobDetail.TbService = &tbSpec.Items[0]
 		} else {
-			fmt.Println(fmt.Sprintf("Couldn't find a TensorBoard service for TfJob %s", job.Metadata.Name))
+			fmt.Println(fmt.Sprintf("Couldn't find a TensorBoard service for TfJob %s", job.Name))
 		}
 	}
 
@@ -141,11 +141,11 @@ func (apiHandler *APIHandler) handleGetTfJobDetail(request *restful.Request, res
 
 func (apiHandler *APIHandler) handleDeploy(request *restful.Request, response *restful.Response) {
 	client := apiHandler.cManager.TfJobClient
-	spec := new(spec.TfJob)
-	if err := request.ReadEntity(spec); err != nil {
+	tfJob := new(v1alpha1.TfJob)
+	if err := request.ReadEntity(tfJob); err != nil {
 		panic(err)
 	}
-	j, err := client.Create(spec.Metadata.Namespace, spec)
+	j, err := client.TensorflowV1alpha1().TfJobs(tfJob.Namespace).Create(tfJob)
 	if err != nil {
 		panic(err)
 	}
@@ -156,7 +156,7 @@ func (apiHandler *APIHandler) handleDeleteTfJob(request *restful.Request, respon
 	namespace := request.PathParameter("namespace")
 	name := request.PathParameter("tfjob")
 	client := apiHandler.cManager.TfJobClient
-	err := client.Delete(namespace, name)
+	err := client.TensorflowV1alpha1().TfJobs(namespace).Delete(name, &metav1.DeleteOptions{})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
we should remove `/Users/admin/go/src/github.com/tensorflow/k8s/pkg/util/k8sutil/tf_job_client.go` soon when we refactor controller logic
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/258)
<!-- Reviewable:end -->
