### PR TITLE
types.go: Fix CRDKind

### DIFF
--- a/pkg/apis/tensorflow/v1alpha1/types.go
+++ b/pkg/apis/tensorflow/v1alpha1/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	CRDKind       = "TfJob"
+	CRDKind       = "tfjob"
 	CRDKindPlural = "tfjobs"
 	CRDGroup      = "tensorflow.org"
 	CRDVersion    = "v1alpha1"


### PR DESCRIPTION
Close #274 

I am not sure why the typo is not reported by our tests.


And, besides this, I found another error after this patch:

```
ERROR: logging before flag.Parse: I0110 16:52:24.938826    3707 controller.go:117] Starting TfJob controller
ERROR: logging before flag.Parse: I0110 16:52:24.938863    3707 controller.go:120] Waiting for informer caches to sync
ERROR: logging before flag.Parse: E0110 16:52:24.998866    3707 runtime.go:66] Observed a panic: &errors.errorString{s:"*v1alpha1.TfJobList does not implement the List interface"} (*v1alpha1.TfJobList does not implement the List interface)
```

Signed-off-by: Ce Gao <ce.gao@outlook.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/276)
<!-- Reviewable:end -->
