### PR TITLE
examples: Hack the validate

### DIFF
--- a/examples/tf_job.yaml
+++ b/examples/tf_job.yaml
@@ -22,3 +22,8 @@ spec:
           restartPolicy: OnFailure
     - replicas: 2
       tfReplicaType: PS
+      template:
+        spec:
+          containers:
+            - image: gcr.io/tf-on-k8s-dogfood/tf_sample:dc944ff
+              name: tensorflow


### PR DESCRIPTION
Now we will check if the container's name in template is `tensorflow`: https://github.com/tensorflow/k8s/blob/master/pkg/apis/tensorflow/validation/validation.go#L44

And the PS in the example do not have the template. This is a hack to make examples work. I am not sure why we check the name `tensorflow`. And, the name is used in https://github.com/tensorflow/k8s/blob/519b0acb32514f08a652ca69471f398f333980f1/pkg/apis/tensorflow/helper/helpers.go#L33

Then now we have to define a template for the PS, which is not cool, IMO. 

Signed-off-by: Ce Gao <ce.gao@outlook.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/287)
<!-- Reviewable:end -->
