### PR TITLE
*: Fix API Version

### DIFF
--- a/pkg/apis/tensorflow/helper/helpers.go
+++ b/pkg/apis/tensorflow/helper/helpers.go
@@ -7,6 +7,15 @@ import (
 	"github.com/tensorflow/k8s/pkg/util"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	groupVersionKind = schema.GroupVersionKind{
+		Group:   tfv1.GroupName,
+		Version: tfv1.GroupVersion,
+		Kind:    tfv1.TFJobResourceKind,
+	}
 )
 
 // AsOwner make OwnerReference according to the parameter
@@ -14,8 +23,8 @@ func AsOwner(tfJob *tfv1.TfJob) metav1.OwnerReference {
 	trueVar := true
 	// Both api.OwnerReference and metatypes.OwnerReference are combined into that.
 	return metav1.OwnerReference{
-		APIVersion:         tfJob.APIVersion,
-		Kind:               tfJob.Kind,
+		APIVersion:         groupVersionKind.GroupVersion().String(),
+		Kind:               groupVersionKind.Kind,
 		Name:               tfJob.ObjectMeta.Name,
 		UID:                tfJob.ObjectMeta.UID,
 		Controller:         &trueVar,

--- a/pkg/apis/tensorflow/v1alpha1/register.go
+++ b/pkg/apis/tensorflow/v1alpha1/register.go
@@ -11,8 +11,14 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
-// GroupName is the group name use in this package
-const GroupName = "tensorflow.org"
+const (
+	// GroupName is the group name use in this package.
+	GroupName = "tensorflow.org"
+	// TFJobResourceKind is the kind name.
+	TFJobResourceKind = "TfJob"
+	// GroupVersion is the version.
+	GroupVersion = "v1alpha1"
+)
 
 // SchemeGroupVersion is the group version used to register these objects.
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: CRDVersion}

--- a/pkg/trainer/replicas_test.go
+++ b/pkg/trainer/replicas_test.go
@@ -16,7 +16,16 @@ import (
 	"github.com/tensorflow/k8s/pkg/util"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
+)
+
+var (
+	groupVersionKind = schema.GroupVersionKind{
+		Group:   tfv1alpha1.GroupName,
+		Version: tfv1alpha1.GroupVersion,
+		Kind:    tfv1alpha1.TFJobResourceKind,
+	}
 )
 
 func TestTFReplicaSet(t *testing.T) {
@@ -66,8 +75,8 @@ func TestTFReplicaSet(t *testing.T) {
 
 	trueVal := true
 	expectedOwnerReference := meta_v1.OwnerReference{
-		APIVersion:         "",
-		Kind:               "",
+		APIVersion:         groupVersionKind.GroupVersion().String(),
+		Kind:               groupVersionKind.Kind,
 		Name:               "some-job",
 		UID:                "some-uid",
 		Controller:         &trueVal,

--- a/pkg/trainer/tensorboard_test.go
+++ b/pkg/trainer/tensorboard_test.go
@@ -65,8 +65,8 @@ func TestTBReplicaSet(t *testing.T) {
 
 	trueVal := true
 	expectedOwnerReference := meta_v1.OwnerReference{
-		APIVersion:         "",
-		Kind:               "",
+		APIVersion:         groupVersionKind.GroupVersion().String(),
+		Kind:               groupVersionKind.Kind,
 		Name:               "some-job",
 		UID:                "some-uid",
 		Controller:         &trueVal,


### PR DESCRIPTION
Close #288 

The API version from the event is empty, we should use the definition in apis, or we can not create the resources.

Signed-off-by: Ce Gao <ce.gao@outlook.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/289)
<!-- Reviewable:end -->
