### PR TITLE
Fix the junit XML file format.

### DIFF
--- a/py/deploy.py
+++ b/py/deploy.py
@@ -115,6 +115,12 @@ def test(args):
     util.run(["helm", "test", "tf-job"])
   except subprocess.CalledProcessError as e:
     t.failure = "helm test failed;\n" + e.output
+    # Reraise the exception so that the prow job will fail and the test
+    # is marked as a failure.
+    # TODO(jlewi): It would be better to this wholistically; e.g. by
+    # processing all the junit xml files and checking for any failures. This
+    # should be more tractable when we migrate off Airflow to Argo.
+    raise
   finally:
     t.time = time.time() - start
     t.name = "e2e-test"

--- a/py/test_util.py
+++ b/py/test_util.py
@@ -122,13 +122,16 @@ def create_junit_xml_file(test_cases, output_path, gcs_client=None):
     # If the time isn't set and no message is set we interpret that as
     # the test not being run.
     if not c.time and not c.failure:
-      attrib["failure"] = "Test was not run."
+      c.failure = "Test was not run."
 
-    if c.failure:
-      attrib["failure"] = c.failure
     e = ElementTree.Element("testcase", attrib)
 
     root.append(e)
+
+    if c.failure:
+      f = ElementTree.Element("failure")
+      f.text = c.failure
+      e.append(f)
 
   t = ElementTree.ElementTree(root)
   logging.info("Creating %s", output_path)

--- a/py/test_util_test.py
+++ b/py/test_util_test.py
@@ -28,9 +28,9 @@ class XMLTest(unittest.TestCase):
       print(output)
     expected = ("""<testsuite failures="1" tests="2" time="20">"""
                 """<testcase classname="some_test" name="first" time="10" />"""
-                """<testcase classname="some_test" """
-                """failure="failed for some reason." name="first" """
-                """time="10" /></testsuite>""")
+                """<testcase classname="some_test" name="first" """
+                """time="10"><failure>failed for some reason.</failure>"""
+                """</testcase></testsuite>""")
 
     self.assertEquals(expected, output)
 


### PR DESCRIPTION
* Test failures weren't being properly reported to gubernator because we had
  the wrong XML format. We need to use a nested failure tag and specify the
  message inside the tag.

* Gubernator still reports the test as succeeded even if there were failures (I think we need to exit with now zero exit code from the prow job). I'll fix that in a follow on PR. In the meantime this allows us to see test failures if we click through to the gubernator dashboard.

* Related to #280

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/291)
<!-- Reviewable:end -->
