### PR TITLE
Fix a bunch of problems in TfJob CRD that crept in while tests were broken

### DIFF
--- a/pkg/apis/tensorflow/v1alpha1/types.go
+++ b/pkg/apis/tensorflow/v1alpha1/types.go
@@ -136,7 +136,6 @@ type ReplicaState string
 
 const (
 	ReplicaStateUnknown   ReplicaState = "Unknown"
-	ReplicaStateStarting  ReplicaState = "Starting"
 	ReplicaStateRunning   ReplicaState = "Running"
 	ReplicaStateFailed    ReplicaState = "Failed"
 	ReplicaStateSucceeded ReplicaState = "Succeeded"

--- a/pkg/apis/tensorflow/validation/validation.go
+++ b/pkg/apis/tensorflow/validation/validation.go
@@ -13,10 +13,10 @@ func ValidateTfJobSpec(c *tfv1.TfJobSpec) error {
 	if c.TerminationPolicy == nil || c.TerminationPolicy.Chief == nil  {
 		return fmt.Errorf("invalid termination policy: %v", c.TerminationPolicy)
 	}
-	// Check that each replica has a TensorFlow container.
+
 	chiefExists := false
 
-	// Check that each replica has a TensorFlow container.
+	// Check that each replica has a TensorFlow container and a chief.
 	for _, r := range c.ReplicaSpecs {
 		found := false
 		if r.Template == nil && r.TfReplicaType != tfv1.PS {

--- a/pkg/apis/tensorflow/validation/validation.go
+++ b/pkg/apis/tensorflow/validation/validation.go
@@ -61,5 +61,8 @@ func ValidateTfJobSpec(c *tfv1.TfJobSpec) error {
 		return fmt.Errorf("Missing ReplicaSpec for chief: %v", c.TerminationPolicy.Chief.ReplicaName)
 	}
 
+	if c.TensorBoard != nil && c.TensorBoard.LogDir == "" {
+			return fmt.Errorf("tbReplicaSpec.LogDir must be specified")
+	}
 	return nil
 }

--- a/pkg/apis/tensorflow/validation/validation.go
+++ b/pkg/apis/tensorflow/validation/validation.go
@@ -10,7 +10,7 @@ import (
 
 // ValidateTfJobSpec checks that the TfJobSpec is valid.
 func ValidateTfJobSpec(c *tfv1.TfJobSpec) error {
-	if c.TerminationPolicy == nil || c.TerminationPolicy.Chief == nil  {
+	if c.TerminationPolicy == nil || c.TerminationPolicy.Chief == nil {
 		return fmt.Errorf("invalid termination policy: %v", c.TerminationPolicy)
 	}
 
@@ -62,7 +62,7 @@ func ValidateTfJobSpec(c *tfv1.TfJobSpec) error {
 	}
 
 	if c.TensorBoard != nil && c.TensorBoard.LogDir == "" {
-			return fmt.Errorf("tbReplicaSpec.LogDir must be specified")
+		return fmt.Errorf("tbReplicaSpec.LogDir must be specified")
 	}
 	return nil
 }

--- a/pkg/apis/tensorflow/validation/validation_test.go
+++ b/pkg/apis/tensorflow/validation/validation_test.go
@@ -1,0 +1,98 @@
+package validation
+
+import (
+  tfv1 "github.com/tensorflow/k8s/pkg/apis/tensorflow/v1alpha1"
+  "testing"
+
+  "github.com/gogo/protobuf/proto"
+  "k8s.io/api/core/v1"
+)
+
+func TestValidate(t *testing.T) {
+  type testCase struct {
+    in       *tfv1.TfJobSpec
+    expectingError bool
+  }
+
+  testCases := []testCase{
+    {
+      in: &tfv1.TfJobSpec{
+        ReplicaSpecs: []*tfv1.TfReplicaSpec{
+          {
+            Template: &v1.PodTemplateSpec{
+              Spec: v1.PodSpec{
+                Containers: []v1.Container{
+                  {
+                    Name: "tensorflow",
+                  },
+                },
+              },
+            },
+            TfReplicaType: tfv1.MASTER,
+            Replicas: proto.Int32(1),
+          },
+        },
+        TfImage: "tensorflow/tensorflow:1.3.0",
+      },
+      expectingError: false,
+    },
+    {
+      in: &tfv1.TfJobSpec{
+        ReplicaSpecs: []*tfv1.TfReplicaSpec{
+          {
+            Template: &v1.PodTemplateSpec{
+              Spec: v1.PodSpec{
+                Containers: []v1.Container{
+                  {
+                    Name: "tensorflow",
+                  },
+                },
+              },
+            },
+            TfReplicaType: tfv1.WORKER,
+            Replicas: proto.Int32(1),
+          },
+        },
+        TfImage: "tensorflow/tensorflow:1.3.0",
+      },
+      expectingError: true,
+    },
+    {
+      in: &tfv1.TfJobSpec{
+        ReplicaSpecs: []*tfv1.TfReplicaSpec{
+          {
+            Template: &v1.PodTemplateSpec{
+              Spec: v1.PodSpec{
+                Containers: []v1.Container{
+                  {
+                    Name: "tensorflow",
+                  },
+                },
+              },
+            },
+            TfReplicaType: tfv1.WORKER,
+            Replicas: proto.Int32(1),
+          },
+        },
+        TfImage: "tensorflow/tensorflow:1.3.0",
+        TerminationPolicy: &tfv1.TerminationPolicySpec{
+          Chief: &tfv1.ChiefSpec{
+            ReplicaName: "WORKER",
+            ReplicaIndex: 0,
+          },
+        },
+      },
+      expectingError: false,
+    },
+  }
+
+  for _, c := range testCases {
+    job := &tfv1.TfJob{
+      Spec: *c.in,
+    }
+    tfv1.SetObjectDefaults_TfJob(job)
+    if err := ValidateTfJobSpec(&job.Spec); (err != nil) != c.expectingError {
+      t.Errorf("unexpected validation result: %v", err)
+    }
+  }
+}

--- a/pkg/apis/tensorflow/validation/validation_test.go
+++ b/pkg/apis/tensorflow/validation/validation_test.go
@@ -1,98 +1,99 @@
 package validation
 
 import (
-  tfv1 "github.com/tensorflow/k8s/pkg/apis/tensorflow/v1alpha1"
-  "testing"
+	"testing"
 
-  "github.com/gogo/protobuf/proto"
-  "k8s.io/api/core/v1"
+	tfv1 "github.com/tensorflow/k8s/pkg/apis/tensorflow/v1alpha1"
+
+	"github.com/gogo/protobuf/proto"
+	"k8s.io/api/core/v1"
 )
 
 func TestValidate(t *testing.T) {
-  type testCase struct {
-    in       *tfv1.TfJobSpec
-    expectingError bool
-  }
+	type testCase struct {
+		in             *tfv1.TfJobSpec
+		expectingError bool
+	}
 
-  testCases := []testCase{
-    {
-      in: &tfv1.TfJobSpec{
-        ReplicaSpecs: []*tfv1.TfReplicaSpec{
-          {
-            Template: &v1.PodTemplateSpec{
-              Spec: v1.PodSpec{
-                Containers: []v1.Container{
-                  {
-                    Name: "tensorflow",
-                  },
-                },
-              },
-            },
-            TfReplicaType: tfv1.MASTER,
-            Replicas: proto.Int32(1),
-          },
-        },
-        TfImage: "tensorflow/tensorflow:1.3.0",
-      },
-      expectingError: false,
-    },
-    {
-      in: &tfv1.TfJobSpec{
-        ReplicaSpecs: []*tfv1.TfReplicaSpec{
-          {
-            Template: &v1.PodTemplateSpec{
-              Spec: v1.PodSpec{
-                Containers: []v1.Container{
-                  {
-                    Name: "tensorflow",
-                  },
-                },
-              },
-            },
-            TfReplicaType: tfv1.WORKER,
-            Replicas: proto.Int32(1),
-          },
-        },
-        TfImage: "tensorflow/tensorflow:1.3.0",
-      },
-      expectingError: true,
-    },
-    {
-      in: &tfv1.TfJobSpec{
-        ReplicaSpecs: []*tfv1.TfReplicaSpec{
-          {
-            Template: &v1.PodTemplateSpec{
-              Spec: v1.PodSpec{
-                Containers: []v1.Container{
-                  {
-                    Name: "tensorflow",
-                  },
-                },
-              },
-            },
-            TfReplicaType: tfv1.WORKER,
-            Replicas: proto.Int32(1),
-          },
-        },
-        TfImage: "tensorflow/tensorflow:1.3.0",
-        TerminationPolicy: &tfv1.TerminationPolicySpec{
-          Chief: &tfv1.ChiefSpec{
-            ReplicaName: "WORKER",
-            ReplicaIndex: 0,
-          },
-        },
-      },
-      expectingError: false,
-    },
-  }
+	testCases := []testCase{
+		{
+			in: &tfv1.TfJobSpec{
+				ReplicaSpecs: []*tfv1.TfReplicaSpec{
+					{
+						Template: &v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "tensorflow",
+									},
+								},
+							},
+						},
+						TfReplicaType: tfv1.MASTER,
+						Replicas:      proto.Int32(1),
+					},
+				},
+				TfImage: "tensorflow/tensorflow:1.3.0",
+			},
+			expectingError: false,
+		},
+		{
+			in: &tfv1.TfJobSpec{
+				ReplicaSpecs: []*tfv1.TfReplicaSpec{
+					{
+						Template: &v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "tensorflow",
+									},
+								},
+							},
+						},
+						TfReplicaType: tfv1.WORKER,
+						Replicas:      proto.Int32(1),
+					},
+				},
+				TfImage: "tensorflow/tensorflow:1.3.0",
+			},
+			expectingError: true,
+		},
+		{
+			in: &tfv1.TfJobSpec{
+				ReplicaSpecs: []*tfv1.TfReplicaSpec{
+					{
+						Template: &v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "tensorflow",
+									},
+								},
+							},
+						},
+						TfReplicaType: tfv1.WORKER,
+						Replicas:      proto.Int32(1),
+					},
+				},
+				TfImage: "tensorflow/tensorflow:1.3.0",
+				TerminationPolicy: &tfv1.TerminationPolicySpec{
+					Chief: &tfv1.ChiefSpec{
+						ReplicaName:  "WORKER",
+						ReplicaIndex: 0,
+					},
+				},
+			},
+			expectingError: false,
+		},
+	}
 
-  for _, c := range testCases {
-    job := &tfv1.TfJob{
-      Spec: *c.in,
-    }
-    tfv1.SetObjectDefaults_TfJob(job)
-    if err := ValidateTfJobSpec(&job.Spec); (err != nil) != c.expectingError {
-      t.Errorf("unexpected validation result: %v", err)
-    }
-  }
+	for _, c := range testCases {
+		job := &tfv1.TfJob{
+			Spec: *c.in,
+		}
+		tfv1.SetObjectDefaults_TfJob(job)
+		if err := ValidateTfJobSpec(&job.Spec); (err != nil) != c.expectingError {
+			t.Errorf("unexpected validation result: %v", err)
+		}
+	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -198,7 +198,9 @@ func (c *Controller) syncTFJob(key string) (bool, error) {
 		return false, err
 	}
 
-	if _, ok := c.jobs[tfJob.ObjectMeta.Namespace+"-"+tfJob.ObjectMeta.Name]; !ok {
+	// Create a new TrainingJob if there is no TrainingJob stored for it in the jobs map or if the UID's don't match.
+	// The UID's won't match in the event we deleted the job and then recreated the job with the samee name.
+	if cJob, ok := c.jobs[tfJob.ObjectMeta.Namespace+"-"+tfJob.ObjectMeta.Name]; !ok || cJob.UID() != tfJob.UID {
 		nc, err := trainer.NewJob(c.KubeClient, c.TfJobClient, tfJob, &c.config)
 
 		if err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -169,7 +169,7 @@ func (c *Controller) processNextWorkItem() bool {
 	return true
 }
 
-// syncJob will sync the job with the given. This function is not meant to be invoked
+// syncTFJob will sync the job with the given. This function is not meant to be invoked
 // concurrently with the same key.
 //
 // When a job is completely processed it will return true indicating that its ok to forget about this job since

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -89,7 +89,7 @@ func New(kubeClient kubernetes.Interface, apiExtclient apiextensionsclient.Inter
 				}
 			},
 			Handler: cache.ResourceEventHandlerFuncs{
-				AddFunc:    controller.enqueueController,
+				AddFunc: controller.enqueueController,
 				UpdateFunc: func(oldObj, newObj interface{}) {
 					controller.enqueueController(newObj)
 				},

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -159,9 +159,6 @@ func (c *Controller) processNextWorkItem() bool {
 	if err == nil {
 		if forget {
 			c.WorkQueue.Forget(key)
-		} else {
-			// Requeue the key so that we will reconcile it again even if no events occur.
-			c.WorkQueue.AddAfter(key.(string), time.Second * 10)
 		}
 		return true
 	}

--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -17,7 +17,7 @@ import (
 	"github.com/tensorflow/k8s/pkg/client/clientset/versioned/scheme"
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
-
+	"k8s.io/apimachinery/pkg/types"
 	"github.com/tensorflow/k8s/pkg/apis/tensorflow/helper"
 )
 
@@ -79,6 +79,10 @@ func NewJob(kubeCli kubernetes.Interface, tfJobClient tfjobclient.Interface, job
 	}
 
 	return j, nil
+}
+
+func (j *TrainingJob) UID() types.UID {
+	return j.job.ObjectMeta.UID
 }
 
 func (j *TrainingJob) ClusterSpec() ClusterSpec {
@@ -319,7 +323,7 @@ func (j *TrainingJob) updateTPRStatus() error {
 // reconcile tries to get the job into the desired state.
 func (j *TrainingJob) Reconcile(config *tfv1alpha1.ControllerConfig) error {
 	log.Infof("DO NOT SUBMIT reconcile called.")
-	if j.status.Phase == tfv1alpha1.TfJobPhaseNone {
+	if j.job.Status.Phase == tfv1alpha1.TfJobPhaseNone {
 		// The job hasn't been setup.
 		j.setup(config)
 

--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -11,14 +11,14 @@ import (
 
 	"strings"
 
+	"github.com/tensorflow/k8s/pkg/apis/tensorflow/helper"
 	tfv1alpha1 "github.com/tensorflow/k8s/pkg/apis/tensorflow/v1alpha1"
 	"github.com/tensorflow/k8s/pkg/apis/tensorflow/validation"
 	tfjobclient "github.com/tensorflow/k8s/pkg/client/clientset/versioned"
 	"github.com/tensorflow/k8s/pkg/client/clientset/versioned/scheme"
 	"k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/apimachinery/pkg/types"
-	"github.com/tensorflow/k8s/pkg/apis/tensorflow/helper"
+	"k8s.io/client-go/kubernetes"
 )
 
 // TODO(jlewi): We should switch a New pattern and make trainingJob private so we can
@@ -155,14 +155,14 @@ func (j *TrainingJob) GetStatus() (tfv1alpha1.State, []*tfv1alpha1.TfReplicaStat
 
 		replicaStatuses = append(replicaStatuses, &rStatus)
 
-		if string(r.Spec.TfReplicaType) == string(chief.ReplicaName) {
+		if string(r.Spec.TfReplicaType) == chief.ReplicaName {
 			chiefState = r.GetSingleReplicaStatus(int32(chief.ReplicaIndex))
 		}
 	}
 
 	if chiefState == tfv1alpha1.ReplicaStateRunning {
 		state = tfv1alpha1.StateRunning
-	} else if chiefState == tfv1alpha1.ReplicaStateFailed{
+	} else if chiefState == tfv1alpha1.ReplicaStateFailed {
 		state = tfv1alpha1.StateFailed
 	} else if chiefState == tfv1alpha1.ReplicaStateSucceeded {
 		state = tfv1alpha1.StateSucceeded

--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -322,7 +322,6 @@ func (j *TrainingJob) updateTPRStatus() error {
 
 // reconcile tries to get the job into the desired state.
 func (j *TrainingJob) Reconcile(config *tfv1alpha1.ControllerConfig) error {
-	log.Infof("DO NOT SUBMIT reconcile called.")
 	if j.job.Status.Phase == tfv1alpha1.TfJobPhaseNone {
 		// The job hasn't been setup.
 		j.setup(config)

--- a/pkg/trainer/training_test.go
+++ b/pkg/trainer/training_test.go
@@ -231,7 +231,7 @@ func TestJobSetup(t *testing.T) {
 					},
 					TerminationPolicy: &tfv1alpha1.TerminationPolicySpec{
 						Chief: &tfv1alpha1.ChiefSpec{
-							ReplicaName: string(tfv1alpha1.WORKER),
+							ReplicaName:  string(tfv1alpha1.WORKER),
 							ReplicaIndex: 0,
 						},
 					},
@@ -269,7 +269,7 @@ func TestJobSetup(t *testing.T) {
 					TensorBoard: &tfv1alpha1.TensorBoardSpec{},
 					TerminationPolicy: &tfv1alpha1.TerminationPolicySpec{
 						Chief: &tfv1alpha1.ChiefSpec{
-							ReplicaName: string(tfv1alpha1.WORKER),
+							ReplicaName:  string(tfv1alpha1.WORKER),
 							ReplicaIndex: 0,
 						},
 					},

--- a/pkg/trainer/training_test.go
+++ b/pkg/trainer/training_test.go
@@ -151,7 +151,7 @@ func TestClusterSpec(t *testing.T) {
 		}
 
 		job.setup(&tfv1alpha1.ControllerConfig{})
-
+		job.setupReplicas()
 		actual := job.ClusterSpec()
 
 		for k, v := range c.Expected {
@@ -278,7 +278,7 @@ func TestJobSetup(t *testing.T) {
 			expectMounts: 0,
 			expectPhase:  tfv1alpha1.TfJobPhaseFailed,
 			expectState:  tfv1alpha1.StateFailed,
-			expectReason: "tbReplicaSpec.LogDir must be specified",
+			expectReason: "invalid job spec: tbReplicaSpec.LogDir must be specified",
 		},
 	}
 

--- a/pkg/trainer/training_test.go
+++ b/pkg/trainer/training_test.go
@@ -185,7 +185,7 @@ func TestJobSetup(t *testing.T) {
 				Spec: tfv1alpha1.TfJobSpec{
 					ReplicaSpecs: []*tfv1alpha1.TfReplicaSpec{
 						{
-							Replicas: proto.Int32(2),
+							Replicas: proto.Int32(1),
 							TfPort:   proto.Int32(10),
 							Template: &v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
@@ -196,7 +196,7 @@ func TestJobSetup(t *testing.T) {
 									},
 								},
 							},
-							TfReplicaType: tfv1alpha1.PS,
+							TfReplicaType: tfv1alpha1.MASTER,
 						},
 					},
 				},
@@ -226,7 +226,13 @@ func TestJobSetup(t *testing.T) {
 									},
 								},
 							},
-							TfReplicaType: tfv1alpha1.PS,
+							TfReplicaType: tfv1alpha1.WORKER,
+						},
+					},
+					TerminationPolicy: &tfv1alpha1.TerminationPolicySpec{
+						Chief: &tfv1alpha1.ChiefSpec{
+							ReplicaName: string(tfv1alpha1.WORKER),
+							ReplicaIndex: 0,
 						},
 					},
 				},
@@ -257,10 +263,16 @@ func TestJobSetup(t *testing.T) {
 									},
 								},
 							},
-							TfReplicaType: tfv1alpha1.PS,
+							TfReplicaType: tfv1alpha1.WORKER,
 						},
 					},
 					TensorBoard: &tfv1alpha1.TensorBoardSpec{},
+					TerminationPolicy: &tfv1alpha1.TerminationPolicySpec{
+						Chief: &tfv1alpha1.ChiefSpec{
+							ReplicaName: string(tfv1alpha1.WORKER),
+							ReplicaIndex: 0,
+						},
+					},
 				},
 			},
 			expectMounts: 0,

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -54,7 +54,7 @@ def run_test(args):
     results = tf_job_client.wait_for_job(api_client, namespace, name,
                                          status_callback=tf_job_client.log_status)
 
-    if results["status"]["state"] != "succeeded":
+    if results["status"]["state"].lower() != "succeeded":
       t.failure = "Job {0} in namespace {1} in state {2}".format(
         name, namespace, results["status"]["state"])
 


### PR DESCRIPTION
* In syncTfJob when checking whether a work queue item corresponds to a TrainingJob already in the map we need to check the UID. Otherwise we will not properly handle the case where a training job is deleted and then a new job is recreated with the same name.
* We need to make sure that the Replicas field in TrainingJob is always properly set;
    * We were only initializing replicas in setup which was problematic in the case where the TfJob controller gets restarted because on restarted setup won't be invoked because the job is past that phase and as a result the replicas won't be reinitialized.
* test_runner needs to ignore case when checking whether the job succeeded otherwise we conclude
  that successful jobs failed
* The controller should only forget about job after the job has been cleaned up; not when it is marked as succeeded or failed.
* Add back code to support termination policies use the worker and not the master as the chief
  * This was added in #221 and accidentally removed in the refactor in #234.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/308)
<!-- Reviewable:end -->
