### PR TITLE
pkg: Add recorder support

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,32 +1,40 @@
-// package controller provides a Kubernetes controller for a TensorFlow job resource.
+// Package controller provides a Kubernetes controller for a TensorFlow job resource.
 package controller
 
 import (
 	"errors"
 	"fmt"
-
 	"reflect"
 	"time"
 
-	"github.com/tensorflow/k8s/pkg/trainer"
-	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
-
 	"github.com/golang/glog"
-	"github.com/tensorflow/k8s/pkg/apis/tensorflow/helper"
-	tfv1alpha1 "github.com/tensorflow/k8s/pkg/apis/tensorflow/v1alpha1"
-	tfjobclient "github.com/tensorflow/k8s/pkg/client/clientset/versioned"
-	informers "github.com/tensorflow/k8s/pkg/client/informers/externalversions"
-	listers "github.com/tensorflow/k8s/pkg/client/listers/tensorflow/v1alpha1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/tensorflow/k8s/pkg/apis/tensorflow/helper"
+	tfv1alpha1 "github.com/tensorflow/k8s/pkg/apis/tensorflow/v1alpha1"
+	tfjobclient "github.com/tensorflow/k8s/pkg/client/clientset/versioned"
+	kubeflowscheme "github.com/tensorflow/k8s/pkg/client/clientset/versioned/scheme"
+	informers "github.com/tensorflow/k8s/pkg/client/informers/externalversions"
+	listers "github.com/tensorflow/k8s/pkg/client/listers/tensorflow/v1alpha1"
+	"github.com/tensorflow/k8s/pkg/trainer"
+)
+
+const (
+	controllerName = "kubeflow"
 )
 
 var (
@@ -42,7 +50,7 @@ var (
 
 type Controller struct {
 	KubeClient   kubernetes.Interface
-	ApiExtclient apiextensionsclient.Interface
+	APIExtclient apiextensionsclient.Interface
 	TfJobClient  tfjobclient.Interface
 
 	config tfv1alpha1.ControllerConfig
@@ -58,18 +66,30 @@ type Controller struct {
 	// simultaneously in two different workers.
 	WorkQueue workqueue.RateLimitingInterface
 
+	// recorder is an event recorder for recording Event resources to the
+	// Kubernetes API.
+	recorder record.EventRecorder
+
 	syncHandler func(jobKey string) (bool, error)
 }
 
-func New(kubeClient kubernetes.Interface, apiExtclient apiextensionsclient.Interface, tfJobClient tfjobclient.Interface,
+func New(kubeClient kubernetes.Interface, APIExtclient apiextensionsclient.Interface, tfJobClient tfjobclient.Interface,
 	config tfv1alpha1.ControllerConfig, tfJobInformerFactory informers.SharedInformerFactory) (*Controller, error) {
 	tfJobInformer := tfJobInformerFactory.Tensorflow().V1alpha1().TfJobs()
 
+	kubeflowscheme.AddToScheme(scheme.Scheme)
+	glog.V(4).Info("Creating event broadcaster")
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.Infof)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerName})
+
 	controller := &Controller{
 		KubeClient:   kubeClient,
-		ApiExtclient: apiExtclient,
+		APIExtclient: APIExtclient,
 		TfJobClient:  tfJobClient,
 		WorkQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Tfjobs"),
+		recorder:     recorder,
 		// TODO(jlewi)): What to do about cluster.Cluster?
 		jobs:   make(map[string]*trainer.TrainingJob),
 		config: config,
@@ -194,7 +214,7 @@ func (c *Controller) syncTFJob(key string) (bool, error) {
 	}
 
 	if _, ok := c.jobs[tfJob.ObjectMeta.Namespace+"-"+tfJob.ObjectMeta.Name]; !ok {
-		nc, err := trainer.NewJob(c.KubeClient, c.TfJobClient, tfJob, &c.config)
+		nc, err := trainer.NewJob(c.KubeClient, c.TfJobClient, c.recorder, tfJob, &c.config)
 
 		if err != nil {
 			return false, err
@@ -261,14 +281,14 @@ func (c *Controller) createCRD() error {
 		},
 	}
 
-	_, err := c.ApiExtclient.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
+	_, err := c.APIExtclient.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 
 	// wait for CRD being established
 	err = wait.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-		crd, err = c.ApiExtclient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(helper.CRDName(), metav1.GetOptions{})
+		crd, err = c.APIExtclient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(helper.CRDName(), metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -288,7 +308,7 @@ func (c *Controller) createCRD() error {
 	})
 
 	if err != nil {
-		deleteErr := c.ApiExtclient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(helper.CRDName(), nil)
+		deleteErr := c.APIExtclient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(helper.CRDName(), nil)
 		if deleteErr != nil {
 			return k8sErrors.NewAggregate([]error{err, deleteErr})
 		}

--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tensorflow/k8s/pkg/client/clientset/versioned/scheme"
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/tensorflow/k8s/pkg/apis/tensorflow/helper"
 )
@@ -27,6 +28,8 @@ type TrainingJob struct {
 	job *tfv1alpha1.TfJob
 
 	KubeCli kubernetes.Interface
+
+	recorder record.EventRecorder
 
 	Replicas []*TFReplicaSet
 
@@ -52,10 +55,11 @@ type TaskSpec struct {
 	Index int    `json:"index"`
 }
 
-func initJob(kubeCli kubernetes.Interface, tfJobClient tfjobclient.Interface, job *tfv1alpha1.TfJob) (*TrainingJob, error) {
+func initJob(kubeCli kubernetes.Interface, tfJobClient tfjobclient.Interface, recorder record.EventRecorder, job *tfv1alpha1.TfJob) (*TrainingJob, error) {
 	j := &TrainingJob{
 		KubeCli:     kubeCli,
 		tfJobClient: tfJobClient,
+		recorder:    recorder,
 		Replicas:    make([]*TFReplicaSet, 0),
 		TensorBoard: nil,
 		job:         job,
@@ -72,8 +76,8 @@ func initTensorBoard(clientSet kubernetes.Interface, tj *TrainingJob) (*TBReplic
 	return nil, nil
 }
 
-func NewJob(kubeCli kubernetes.Interface, tfJobClient tfjobclient.Interface, job *tfv1alpha1.TfJob, config *tfv1alpha1.ControllerConfig) (*TrainingJob, error) {
-	j, err := initJob(kubeCli, tfJobClient, job)
+func NewJob(kubeCli kubernetes.Interface, tfJobClient tfjobclient.Interface, recorder record.EventRecorder, job *tfv1alpha1.TfJob, config *tfv1alpha1.ControllerConfig) (*TrainingJob, error) {
+	j, err := initJob(kubeCli, tfJobClient, recorder, job)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +239,7 @@ func (j *TrainingJob) setup(config *tfv1alpha1.ControllerConfig) {
 		}
 
 		for _, t := range j.job.Spec.ReplicaSpecs {
-			r, err := NewTFReplicaSet(j.KubeCli, *t, j)
+			r, err := NewTFReplicaSet(j.KubeCli, j.recorder, *t, j)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR focus on recorder support in Kubernetes. Now we could push events to Kubernetes about the TFJob:

```
Events:
  Type    Reason            Age   From      Message
  ----    ------            ----  ----      -------
  Normal  SuccessfulCreate  9s    kubeflow  Created service: example-job-master-xpnw-0
  Normal  SuccessfulCreate  9s    kubeflow  Created job: example-job-master-xpnw-0
  Normal  SuccessfulCreate  9s    kubeflow  Created service: example-job-worker-xpnw-0
  Normal  SuccessfulCreate  9s    kubeflow  Created job: example-job-worker-xpnw-0
```

Signed-off-by: Ce Gao <ce.gao@outlook.com>