### PR TITLE
Deprecate the ENV MY_POD_NAME and use default namespace

### DIFF
--- a/cmd/tf_operator/app/server.go
+++ b/cmd/tf_operator/app/server.go
@@ -52,9 +52,10 @@ var (
 )
 
 func Run(opt *options.ServerOption) error {
-	namespace := os.Getenv("MY_POD_NAMESPACE")
+	namespace := os.Getenv(util.EnvKubeflowNamespace)
 	if len(namespace) == 0 {
-		glog.Fatalf("must set env MY_POD_NAMESPACE")
+		glog.Infof("EnvKubeflowNamespace not set, use default namespace")
+		namespace = metav1.NamespaceDefault
 	}
 
 	glog.Infof("tf_operator Version: %v", version.Version)

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -136,13 +136,10 @@ a K8s cluster. Set your environment:
 
 ```sh
 export KUBECONFIG=$(echo ~/.kube/config)
-export MY_POD_NAMESPACE=default
-export MY_POD_NAME=my-pod
+export KUBEFLOW_NAMESPACE=$(your_namespace)
 ```
 
-* MY_POD_NAMESPACE is used because the CRD is namespace scoped and we use the namespace of the controller to
-  set the corresponding namespace for the resource.
-* TODO(jlewi): Do we still need to set MY_POD_NAME? Why?
+* KUBEFLOW_NAMESPACE is used when deployed on Kubernetes, we use this variable to create other resources (e.g. the resource lock) internal in the same namespace. It is optional, use `default` namespace if not set.
 
 Now we are ready to run operator locally:
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -7,7 +7,12 @@ import (
 	"math/rand"
 	"time"
 
-	log "github.com/golang/glog"
+	"github.com/golang/glog"
+)
+
+const (
+	// Environment variable for namespace when deployed on kubernetes
+	EnvKubeflowNamespace = "KUBEFLOW_NAMESPACE"
 )
 
 // Pformat returns a pretty format output of any value that can be marshalled to JSON.
@@ -17,7 +22,7 @@ func Pformat(value interface{}) string {
 	}
 	valueJSON, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
-		log.Warningf("Couldn't pretty format %v, error: %v", value, err)
+		glog.Warningf("Couldn't pretty format %v, error: %v", value, err)
 		return fmt.Sprintf("%v", value)
 	}
 	return string(valueJSON)

--- a/tf-job-operator-chart/templates/deployment.yaml
+++ b/tf-job-operator-chart/templates/deployment.yaml
@@ -24,15 +24,6 @@ spec:
           {{- end }}
           - -alsologtostderr
           - -v=1
-        env:
-        - name: MY_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
       {{- if .Values.config.configmap }}
         volumeMounts:
           - name: config-volume


### PR DESCRIPTION
Hi, this PR fixes https://github.com/tensorflow/k8s/issues/341:

- Deprecate the ENV `MY_POD_NAMESPACE` and `MY_POD_NAME`
- And use `NamespaceDefault` by default

@jlewi PTAL, thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/348)
<!-- Reviewable:end -->
