### PR TITLE
Fix helm test

### DIFF
--- a/examples/tf_job.yaml
+++ b/examples/tf_job.yaml
@@ -22,3 +22,9 @@ spec:
           restartPolicy: OnFailure
     - replicas: 2
       tfReplicaType: PS
+      template:
+        spec:
+          containers:
+            - image: gcr.io/tf-on-k8s-dogfood/tf_sample:dc944ff
+              name: tensorflow
+          restartPolicy: OnFailure

--- a/py/deploy.py
+++ b/py/deploy.py
@@ -114,7 +114,7 @@ def test(args):
     start = time.time()
     util.run(["helm", "test", "tf-job"])
   except subprocess.CalledProcessError as e:
-    t.failure = "helm test failed;\n" + e.output
+    t.failure = "helm test failed;\n" + (e.output or '')
     # Reraise the exception so that the prow job will fail and the test
     # is marked as a failure.
     # TODO(jlewi): It would be better to this wholistically; e.g. by

--- a/py/deploy.py
+++ b/py/deploy.py
@@ -92,7 +92,7 @@ def setup(args):
               "--set", "rbac.install=true,cloud=gke"])
     util.wait_for_deployment(api_client, "default", "tf-job-operator")
   except subprocess.CalledProcessError as e:
-    t.failure = "helm install failed;\n" + e.output
+    t.failure = "helm install failed;\n" + (e.output or "")
   except util.TimeoutError as e:
     t.failure = e.message
   finally:
@@ -114,7 +114,7 @@ def test(args):
     start = time.time()
     util.run(["helm", "test", "tf-job"])
   except subprocess.CalledProcessError as e:
-    t.failure = "helm test failed;\n" + (e.output or '')
+    t.failure = "helm test failed;\n" + (e.output or "")
     # Reraise the exception so that the prow job will fail and the test
     # is marked as a failure.
     # TODO(jlewi): It would be better to this wholistically; e.g. by

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -87,6 +87,17 @@ func run() (string, error) {
 					Replicas:      proto.Int32(1),
 					TFPort:        proto.Int32(2222),
 					TFReplicaType: tfv1alpha1.PS,
+					Template: &v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "tensorflow",
+									Image: *image,
+								},
+							},
+							RestartPolicy: v1.RestartPolicyOnFailure,
+						},
+					},
 				},
 				{
 					Replicas:      proto.Int32(1),

--- a/test/e2e/simple_job.yaml.template
+++ b/test/e2e/simple_job.yaml.template
@@ -22,3 +22,9 @@ spec:
           restartPolicy: OnFailure
     - replicas: 2
       tfReplicaType: PS
+      template:
+        spec:
+          containers:
+            - image: gcr.io/tf-on-k8s-dogfood/tf_sample:{{image_tag}}
+              name: tensorflow
+          restartPolicy: OnFailure


### PR DESCRIPTION
Helm test was failing because validation for a tfjob required that replicaSpecs for a Parameter server specify a template.  Helm test failure also was not reported.

Changes made:
- Updated e2e tests and examples to include a template for the PS replicaSpec 
- Check for `None` before concatenating the error.

Fixes https://github.com/tensorflow/k8s/issues/351 and https://github.com/tensorflow/k8s/issues/355

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/356)
<!-- Reviewable:end -->
