### PR TITLE
Fix repo name env

### DIFF
--- a/py/util.py
+++ b/py/util.py
@@ -26,7 +26,7 @@ from kubernetes.client import rest
 # We default to environment variables so that it can be set correctly when
 # running under prow.
 MASTER_REPO_OWNER = os.getenv("REPO_OWNER", "tensorflow")
-MASTER_REPO_NAME = os.getenv("REPO_OWNER", "k8s")
+MASTER_REPO_NAME = os.getenv("REPO_NAME", "k8s")
 
 # TODO(jlewi): Should we stream the output by polling the subprocess?
 # look at run_and_stream in build_and_push.


### PR DESCRIPTION
FIxes a typo in the getenv for MASTER_REPO_NAME

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/k8s/372)
<!-- Reviewable:end -->
